### PR TITLE
スプライトを追加した後にモデルを追加するとWVPが更新されないバグを修正。

### DIFF
--- a/Editor/UI/View/InspectorView.cpp
+++ b/Editor/UI/View/InspectorView.cpp
@@ -10,6 +10,8 @@
 #include "Assets/Script/Data/ScriptHandle.h"
 #include "Physics/Force.h"
 #include "Collider/Data/SphereColliderData.h"
+#include "Assets/3DModel/Data/ModelHandle.h"
+#include "Assets/Sprite/Data/SpriteData.h"
 
 InspectorView::InspectorView() {
 	isActive_ = true;
@@ -35,7 +37,6 @@ void InspectorView::Draw() {
 	AssetManager* assetManager = AssetManager::GetInstance();
 	if (assetManager->GetEntityManager()->HasComponent<SceneObjectData>(selectedEntityId_)) {
 		SceneObjectData& sceneObjData = assetManager->GetEntityManager()->GetComponent<SceneObjectData>(selectedEntityId_);
-		ImGui::Text("Entity");
 		ImGui::Text("Entity ID: %d", selectedEntityId_);
 		ImGui::Text("Name: %s", sceneObjData.name.c_str());
 		ImGui::Separator();
@@ -44,87 +45,104 @@ void InspectorView::Draw() {
 		ImGui::End();
 		return;
 	}
+
 	// Transform
 	if (assetManager->GetEntityManager()->HasComponent<Transform>(selectedEntityId_)) {
 		Transform& transform = assetManager->GetEntityManager()->GetComponent<Transform>(selectedEntityId_);
-		ImGui::Text("Transform");
-		ImGui::DragFloat3("Transition", &transform.translate.x, 0.1f);
-		ImGui::DragFloat3("Rotation", &transform.rotate.x, 0.1f);
-		ImGui::DragFloat3("Scale", &transform.scale.x, 0.1f);
-		ImGui::Separator();
+		if (ImGui::CollapsingHeader("Transform")) {
+			ImGui::DragFloat3("Transition", &transform.translate.x, 0.1f);
+			ImGui::DragFloat3("Rotation", &transform.rotate.x, 0.1f);
+			ImGui::DragFloat3("Scale", &transform.scale.x, 0.1f);
+		}
 	}
+	// Model
+	if (assetManager->GetEntityManager()->HasComponent<ModelHandle>(selectedEntityId_)) {
+		ModelHandle& modelHandle = assetManager->GetEntityManager()->GetComponent<ModelHandle>(selectedEntityId_);
+		if (ImGui::CollapsingHeader("Model")) {
+			ImGui::Text("Model Name: %s", modelHandle.modelName.c_str());
+		}
+	}
+	// Sprite
+	if (assetManager->GetEntityManager()->HasComponent<SpriteData>(selectedEntityId_)) {
+		SpriteData& spriteData = assetManager->GetEntityManager()->GetComponent<SpriteData>(selectedEntityId_);
+		if (ImGui::CollapsingHeader("Sprite")) {
+			ImGui::Text("Sprite Name: %s", spriteData.textureName.c_str());
+			ImGui::DragFloat("Width", &spriteData.width, 1.0f, 1.0f);
+			ImGui::DragFloat("Height", &spriteData.height, 1.0f, 1.0f);
+			Material* material = assetManager->GetMaterialBufferManager()->GetBufferData(spriteData.materialBufferHandle);
+			ImGui::ColorEdit4("Color", &material->color.x);
+		}
+	}
+
 	// スクリプト
 	if (assetManager->GetEntityManager()->HasComponent<ScriptHandles>(selectedEntityId_)) {
 		ScriptHandles& scriptHandle = assetManager->GetEntityManager()->GetComponent<ScriptHandles>(selectedEntityId_);
 
-		ImGui::Text("Scripts");
-		ImGui::SameLine();
-		if (ImGui::Button("Delete##Scripts")) {
-			assetManager->GetEntityManager()->RemoveComponent<ScriptHandles>(selectedEntityId_);
-		}
-		std::vector<uint32_t> eraseIndices;
-		for (size_t i = 0; i < scriptHandle.scriptHandles_.size(); ++i) {
-			const auto& sh = scriptHandle.scriptHandles_[i];
-			// リスト表示
-			ImGui::Selectable(sh.scriptName_.c_str());
+		if (ImGui::CollapsingHeader("Scripts")) {
+			if (ImGui::Button("Delete##Scripts")) {
+				assetManager->GetEntityManager()->RemoveComponent<ScriptHandles>(selectedEntityId_);
+			}
+			std::vector<uint32_t> eraseIndices;
+			for (size_t i = 0; i < scriptHandle.scriptHandles_.size(); ++i) {
+				const auto& sh = scriptHandle.scriptHandles_[i];
+				// リスト表示
+				ImGui::Selectable(sh.scriptName_.c_str());
 
-			// 右クリックでポップアップメニュー
-			if (ImGui::BeginPopupContextItem()) {
-				if (ImGui::MenuItem("Open in VSCode")) {
-					LuaScriptResourceManager::GetInstance()->OpenAndEditScript(sh.scriptName_);
+				// 右クリックでポップアップメニュー
+				if (ImGui::BeginPopupContextItem()) {
+					if (ImGui::MenuItem("Open in VSCode")) {
+						LuaScriptResourceManager::GetInstance()->OpenAndEditScript(sh.scriptName_);
+					}
+					if (ImGui::MenuItem("Remove")) {
+						// スクリプト削除処理 
+						eraseIndices.push_back(static_cast<uint32_t>(i));
+						LuaScriptResourceManager::GetInstance()->RequestRemoveScript(sh.handle_);
+					}
+					ImGui::EndPopup();
 				}
-				if (ImGui::MenuItem("Remove")) {
-					// スクリプト削除処理 
-					eraseIndices.push_back(static_cast<uint32_t>(i));
-					LuaScriptResourceManager::GetInstance()->RequestRemoveScript(sh.handle_);
-				}
-				ImGui::EndPopup();
+			}
+			// 後ろから削除してインデックスずれを防ぐ
+			for (auto it = eraseIndices.rbegin(); it != eraseIndices.rend(); ++it) {
+				scriptHandle.scriptHandles_.erase(scriptHandle.scriptHandles_.begin() + *it);
+			}
+			// スクリプトがなくなったらコンポーネントごと削除
+			if (scriptHandle.scriptHandles_.size() <= 0) {
+				assetManager->GetEntityManager()->RemoveComponent<ScriptHandles>(selectedEntityId_);
 			}
 		}
-		// 後ろから削除してインデックスずれを防ぐ
-		for (auto it = eraseIndices.rbegin(); it != eraseIndices.rend(); ++it) {
-			scriptHandle.scriptHandles_.erase(scriptHandle.scriptHandles_.begin() + *it);
-		}
-		// スクリプトがなくなったらコンポーネントごと削除
-		if (scriptHandle.scriptHandles_.size() <= 0) {
-			assetManager->GetEntityManager()->RemoveComponent<ScriptHandles>(selectedEntityId_);
-		}
-		ImGui::Separator();
+
 	}
 	// Force
 	if (assetManager->GetEntityManager()->HasComponent<Force>(selectedEntityId_)) {
 		Force& force = assetManager->GetEntityManager()->GetComponent<Force>(selectedEntityId_);
-		ImGui::Text("Force");
-		ImGui::SameLine();
-		if (ImGui::Button("Delete##Force")) {
-			assetManager->GetEntityManager()->RemoveComponent<Force>(selectedEntityId_);
+		if (ImGui::CollapsingHeader("Force")) {
+			if (ImGui::Button("Delete##Force")) {
+				assetManager->GetEntityManager()->RemoveComponent<Force>(selectedEntityId_);
+			}
+			ImGui::DragFloat3("Velocity", &force.velocity.x, 0.1f);
+			ImGui::DragFloat3("Acceleration", &force.acceleration.x, 0.1f);
+			ImGui::DragFloat("Mass", &force.mass, 0.1f, 0.1f);
+			ImGui::DragFloat("Friction", &force.friction, 0.01f, 0.0f);
+			ImGui::DragFloat("GravityStrength", &force.gravityStrength, 0.01f, 0.0f);
+			ImGui::Checkbox("Use Gravity", &force.isGravity);
 		}
-		ImGui::DragFloat3("Velocity", &force.velocity.x, 0.1f);
-		ImGui::DragFloat3("Acceleration", &force.acceleration.x, 0.1f);
-		ImGui::DragFloat("Mass", &force.mass, 0.1f, 0.1f);
-		ImGui::DragFloat("Friction", &force.friction, 0.01f, 0.0f);
-		ImGui::DragFloat("GravityStrength", &force.gravityStrength, 0.01f, 0.0f);
-		ImGui::Checkbox("Use Gravity", &force.isGravity);
-		ImGui::Separator();
 	}
 	// SphereColliderData
 	if (assetManager->GetEntityManager()->HasComponent<SphereColliderData>(selectedEntityId_)) {
 		SphereColliderData& sphereCollider = assetManager->GetEntityManager()->GetComponent<SphereColliderData>(selectedEntityId_);
-		ImGui::Text("SphereCollider");
-		ImGui::SameLine();
-		if (ImGui::Button("Delete##SphereCollider")) {
-			assetManager->GetEntityManager()->RemoveComponent<SphereColliderData>(selectedEntityId_);
-		}
-		ImGui::Checkbox("Is Trigger", &sphereCollider.isTrigger);
-		ImGui::Checkbox("Is Static", &sphereCollider.isStatic);
-		ImGui::DragFloat3("Center", &sphereCollider.sphere.center.x, 0.1f);
-		ImGui::DragFloat("Radius", &sphereCollider.sphere.radius, 0.1f, 0.1f);
+		if (ImGui::CollapsingHeader("SphereCollider")) {
+			if (ImGui::Button("Delete##SphereCollider")) {
+				assetManager->GetEntityManager()->RemoveComponent<SphereColliderData>(selectedEntityId_);
+			}
+			ImGui::DragFloat3("Center", &sphereCollider.sphere.center.x, 0.1f);
+			ImGui::DragFloat("Radius", &sphereCollider.sphere.radius, 0.1f, 0.1f);
+			ImGui::Checkbox("Is Trigger", &sphereCollider.isTrigger);
+			ImGui::Checkbox("Is Static", &sphereCollider.isStatic);
 #ifdef _DEBUG
-		ImGui::Checkbox("Debug Draw", &sphereCollider.isDraw);
+			ImGui::Checkbox("Debug Draw", &sphereCollider.isDraw);
 #endif // _DEBUG
-		ImGui::Separator();
+		}
 	}
-	
 
 	// コンポーネントの追加
 	if (ImGui::Button("Add Component")) {
@@ -165,7 +183,6 @@ void InspectorView::Draw() {
 			if (scriptList_.GetSelectedFileName(selectedScript)) {
 				SceneManager::GetInstance()->AddScript(selectedEntityId_, selectedScript);
 			}
-
 
 			ImGui::EndMenu();
 		}

--- a/Engine/Platform/Windows/Assets/Sprite/SpriteManager.cpp
+++ b/Engine/Platform/Windows/Assets/Sprite/SpriteManager.cpp
@@ -6,6 +6,31 @@ void SpriteManager::Initialize() {
 	spriteVertexBuffers_.clear();
 }
 
+void SpriteManager::ResizeSprite(uint32_t handle, float width, float height) {
+	assert(handle < spriteVertexBuffers_.size());
+	VertexData* vertexData = spriteVertexBuffers_[handle].GetData();
+	assert(vertexData);
+	float w = width;
+	float h = height;
+	vertexData[0].position = { 0.0f, 0.0f, 0.0f,1.0f };   // 左上
+	vertexData[0].texcoord = { 0.0f, 0.0f };
+	vertexData[0].normal = { 0.0f, 0.0f, 1.0f };
+	vertexData[1].position = { w, 0.0f, 0.0f ,1.0f }; // 右上
+	vertexData[1].texcoord = { 1.0f, 0.0f };
+	vertexData[1].normal = { 0.0f, 0.0f, 1.0f };
+	vertexData[2].position = { 0.0f, h, 0.0f ,1.0f }; // 左下
+	vertexData[2].texcoord = { 0.0f, 1.0f };
+	vertexData[2].normal = { 0.0f, 0.0f,1.0f };
+	vertexData[3].position = { w, h, 0.0f ,1.0f }; // 右下
+	vertexData[3].texcoord = { 1.0f, 1.0f };
+	vertexData[3].normal = { 0.0f, 0.0f, 1.0f };
+	vertexData[4].position = { 0.0f, h, 0.0f,1.0f }; // 左下
+	vertexData[4].texcoord = { 0.0f, 1.0f };
+	vertexData[4].normal = { 0.0f, 0.0f, 1.0f };
+	vertexData[5].position = { w, 0.0f, 0.0f ,1.0f }; // 右上
+	vertexData[5].texcoord = { 1.0f, 0.0f };
+}
+
 uint32_t SpriteManager::CreateVertexBuffer(float width, float height) {
     spriteVertexBuffers_.emplace_back();
 	spriteVertexBuffers_.back().CreateResource(DirectXCommon::GetInstance()->GetDevice(), 6);
@@ -39,6 +64,16 @@ uint32_t SpriteManager::CreateVertexBuffer(float width, float height) {
 
 VertexBuffer<VertexData>* SpriteManager::GetVertexBuffer(uint32_t handle) {
 	return &spriteVertexBuffers_[handle];
+}
+
+Vector2 SpriteManager::GetSpriteSize(uint32_t handle) {
+	if (handle < spriteVertexBuffers_.size()) {
+		VertexData* vertexData = spriteVertexBuffers_[handle].GetData();
+		assert(vertexData);
+		return Vector2(vertexData[1].position.x, vertexData[2].position.y);
+	}
+	assert(false && "Invalid handle");
+	return Vector2();
 }
 
 void SpriteManager::Finalize() {

--- a/Engine/Platform/Windows/Assets/Sprite/SpriteManager.h
+++ b/Engine/Platform/Windows/Assets/Sprite/SpriteManager.h
@@ -8,8 +8,10 @@ public:
 	SpriteManager() = default;
 	~SpriteManager() = default;
 	void Initialize();
+	void ResizeSprite(uint32_t handle, float width, float height);
 	uint32_t CreateVertexBuffer(float width, float height);
 	VertexBuffer<VertexData>* GetVertexBuffer(uint32_t handle);
+	Vector2 GetSpriteSize(uint32_t handle);
 	void Finalize();
 
 private:

--- a/Engine/Platform/Windows/Renderer/ModelRenderer.cpp
+++ b/Engine/Platform/Windows/Renderer/ModelRenderer.cpp
@@ -10,6 +10,8 @@ void Render::Model::DrawModel(const uint32_t& modelHandle) {
 	assert(assetManager && "AssetManager is nullptr.");
 	const ModelRenderData* modelDataPtr = assetManager->GetModelRenderData(modelHandle);
 
+	modelDataPtr->meshRenderDataHandles[0].wpvBufferHandle;
+
 	PipelineStateObject* pso = GraphicPipelineManager::GetInstance()->GetTrianglePso(kBlendModeNormal);
 
 	DirectXCommon* dxCommon = DirectXCommon::GetInstance();

--- a/Engine/Platform/Windows/Scene/SceneManager.cpp
+++ b/Engine/Platform/Windows/Scene/SceneManager.cpp
@@ -55,14 +55,16 @@ void SceneManager::PreDraw() {
 			// モデルのワールド行列更新
 			if (assetManager->GetEntityManager()->HasComponent<ModelHandle>(entityId)) {
 				ModelHandle& modelHandle = assetManager->GetEntityManager()->GetComponent<ModelHandle>(entityId);
-				TransformationMatrix* wpvMatrix = assetManager->GetWpvBufferManager()->GetBufferData(modelHandle.handle);
-				wpvMatrix->World = Matrix4x4::MakeAffineMatrix(
-					transform.scale,
-					transform.rotate,
-					transform.translate
-				);
-
-				wpvMatrix->WVP = cameraManager->GetMainCamera().GetWorldViewProjectionMatrix(wpvMatrix->World,CameraType::Perspective);
+				const ModelRenderData* modelData = assetManager->GetModelRenderData(modelHandle.handle);
+				for (const auto& meshData : modelData->meshRenderDataHandles) {
+					TransformationMatrix* wpvMatrix = assetManager->GetWpvBufferManager()->GetBufferData(meshData.wpvBufferHandle);
+					wpvMatrix->World = Matrix4x4::MakeAffineMatrix(
+						transform.scale,
+						transform.rotate,
+						transform.translate
+					);
+					wpvMatrix->WVP = cameraManager->GetMainCamera().GetWorldViewProjectionMatrix(wpvMatrix->World, CameraType::Perspective);
+				}
 			}
 			// スプライトのワールド行列更新
 			if (assetManager->GetEntityManager()->HasComponent<SpriteData>(entityId)) {

--- a/Engine/Platform/Windows/Scene/SceneObject.cpp
+++ b/Engine/Platform/Windows/Scene/SceneObject.cpp
@@ -25,6 +25,16 @@ void SceneObject::Initialize() {
 }
 
 void SceneObject::Update() {
+	// スプライトサイズ更新
+	if (assetManager_->GetEntityManager()->HasComponentStrage<SpriteData>()) {
+		const auto& spriteStrage = assetManager_->GetEntityManager()->GetComponentStrage<SpriteData>();
+		for (const auto& [entityId, sprite] : spriteStrage) {
+			Vector2 nowSize = assetManager_->GetSpriteManager()->GetSpriteSize(sprite.vertexBufferHandle);
+			if (sprite.width != nowSize.x || sprite.height != nowSize.y) {
+				assetManager_->GetSpriteManager()->ResizeSprite(sprite.vertexBufferHandle, nowSize.x, nowSize.y);
+			}
+		}
+	}
 }
 
 void SceneObject::Draw() {

--- a/Resources/Scenes/NewScene.json
+++ b/Resources/Scenes/NewScene.json
@@ -27,25 +27,19 @@
             }
         },
         {
-            "ModelHandle": {
-                "modelName": "anchor.obj"
-            },
             "SceneObjectData": {
-                "name": "anchor.obj",
+                "name": "uvChecker.png",
                 "tag": "Untagged"
             },
-            "ScriptHandle": {
-                "scriptHandles": [
-                    {
-                        "handle": 8,
-                        "scriptName": "NewScript.lua"
-                    }
-                ]
+            "SpriteData": {
+                "height": 512.0,
+                "textureName": "uvChecker.png",
+                "width": 512.0
             },
             "Transform": {
                 "rotate": [
                     0.0,
-                    -0.0,
+                    0.0,
                     0.0
                 ],
                 "scale": [
@@ -54,8 +48,34 @@
                     1.0
                 ],
                 "translate": [
-                    -0.7646769285202026,
-                    0.2615368068218231,
+                    0.0,
+                    0.0,
+                    0.0
+                ]
+            }
+        },
+        {
+            "ModelHandle": {
+                "modelName": "axis.obj"
+            },
+            "SceneObjectData": {
+                "name": "axis.obj",
+                "tag": "Untagged"
+            },
+            "Transform": {
+                "rotate": [
+                    0.0,
+                    0.0,
+                    0.0
+                ],
+                "scale": [
+                    1.0,
+                    1.0,
+                    1.0
+                ],
+                "translate": [
+                    0.0,
+                    0.0,
                     0.0
                 ]
             }


### PR DESCRIPTION
原因はSceneManagerのPreDrawでmodelRendeerHandleではなくそのままのハンドルでやっていたためスプライトのWvpを更新しようとしてしまっていた