### PR TITLE
エディタUI名管理のリファクタリングと統一

### DIFF
--- a/project/editor/include/UI/IEditorUI.h
+++ b/project/editor/include/UI/IEditorUI.h
@@ -24,9 +24,11 @@ namespace QFE {
 		virtual void Run() {};
 		/** @brief UI名の取得 */
 		std::string GetName() const { return name_; }
+		/** @brief UI名の設定 */
+		void SetName(const std::string& name) { name_ = name; }
 
 		bool isActive_; ///< アクティブ状態
-	protected:
+	private:
 		std::string name_; ///< UI名
 	};
 }

--- a/project/editor/src/UI/Edit/ColliderMaskEdit.cpp
+++ b/project/editor/src/UI/Edit/ColliderMaskEdit.cpp
@@ -7,7 +7,7 @@
 #include "collider/ColliderManager.h"
 using namespace QFE;
 ColliderMaskEdit::ColliderMaskEdit() {
-	name_ = "Collider Mask Edit";
+	SetName("Collider Mask Edit");
 	isActive_ = false;
 }
 

--- a/project/editor/src/UI/Edit/DebugConsole.cpp
+++ b/project/editor/src/UI/Edit/DebugConsole.cpp
@@ -7,7 +7,7 @@
 #include "editor/include/Commands/AllEditorCommands.h"
 using namespace QFE;
 void DebugConsole::Initialize() {
-	name_ = "DebugConsole";
+	SetName("DebugConsole");
 	isActive_ = false;
 
 	commandList_.clear();

--- a/project/editor/src/UI/Edit/KeyConfigEdit.cpp
+++ b/project/editor/src/UI/Edit/KeyConfigEdit.cpp
@@ -12,7 +12,7 @@ using namespace QFE;
 void KeyConfigEdit::Initialize() {
 	isActive_ = false;
 	inputBuf_[0] = '\0';
-	name_ = "KeyConfig Edit";
+	SetName("KeyConfig Edit");
 }
 
 void KeyConfigEdit::Update() {

--- a/project/editor/src/UI/Edit/PostprocessEdit.cpp
+++ b/project/editor/src/UI/Edit/PostprocessEdit.cpp
@@ -2,7 +2,7 @@
 #include "graphic/PostEffect/RenderingPostprocess.h"
 using namespace QFE;
 void PostprocessEdit::Initialize() {
-	name_ = "PostprocessEdit";
+	SetName("Postprocess Edit");
 	isActive_ = false;
 }
 

--- a/project/editor/src/UI/File/CreateNewScene.cpp
+++ b/project/editor/src/UI/File/CreateNewScene.cpp
@@ -7,7 +7,7 @@
 #include "scene/SceneManager.h"
 using namespace QFE;
 void CreateNewScene::Initialize() {
-	name_ = "New Scene";
+	SetName("Create New Scene");
 	isActive_ = false;
 }
 
@@ -18,9 +18,9 @@ void CreateNewScene::Draw() {
 	if (!isActive_) {
 		return;
 	}
-	ImGui::OpenPopup(name_.c_str());
+	ImGui::OpenPopup(GetName().c_str());
 	ImGui::SetNextWindowSize(ImVec2(300, 100), ImGuiCond_Once);
-	if (ImGui::BeginPopupModal(name_.c_str(), NULL, ImGuiWindowFlags_AlwaysAutoResize)) {
+	if (ImGui::BeginPopupModal(GetName().c_str(), NULL, ImGuiWindowFlags_AlwaysAutoResize)) {
 		ImGui::Text("Create a new scene?\n");
 		ImGui::Separator();
 		if (ImGui::Button("Create", ImVec2(120, 0))) {

--- a/project/editor/src/UI/File/LoadScene.cpp
+++ b/project/editor/src/UI/File/LoadScene.cpp
@@ -8,7 +8,7 @@
 using namespace QFE;
 void LoadScene::Initialize() {
 	currentScene_ = "";
-	name_ = "LoadScene";
+	SetName("Load Scene");
 	isActive_ = false;
 	sceneList_.clear();
 	sceneList_ = QFE::FILE::GetFilesInDirectory("Resources/Scenes", ".json");
@@ -26,7 +26,7 @@ void LoadScene::Draw() {
 		return;
 	}
 
-	ImGui::Begin(name_.c_str(), &isActive_, ImGuiWindowFlags_NoDocking);
+	ImGui::Begin(GetName().c_str(), &isActive_, ImGuiWindowFlags_NoDocking);
 	if (ImGui::Button("LoadFiles")) {
 		sceneList_ = QFE::FILE::GetFilesInDirectory("Resources/Scenes", ".json");
 	}

--- a/project/editor/src/UI/File/SaveScene.cpp
+++ b/project/editor/src/UI/File/SaveScene.cpp
@@ -7,7 +7,7 @@
 #include "scene/SceneManager.h"
 using namespace QFE;
 void SaveScene::Initialize() {
-	name_ = "SaveScene";
+	SetName("Save Scene");
 	isActive_ = false;
 	sceneName_ = "NewScene";
 }

--- a/project/editor/src/UI/View/AssetsView.cpp
+++ b/project/editor/src/UI/View/AssetsView.cpp
@@ -17,7 +17,7 @@ AssetsView::AssetsView() {
 	assetManager = AssetManager::GetInstance();
 	assert(assetManager);
 	currentHierarchy = ViewHierarchy::Root;
-	name_ = "Assets View";
+	SetName("Assets");
 	hierarchyNames = {
 		{ViewHierarchy::Root, "Root"},
 		{ViewHierarchy::Images, "Images"},
@@ -65,7 +65,7 @@ void AssetsView::Draw() {
 		return;
 	}
 
-	ImGui::Begin(name_.c_str(), &isActive_);
+	ImGui::Begin(GetName().c_str(), &isActive_);
 
 	// メモリ/ファイル表示の切り替えラジオボタン
 	if (ImGui::RadioButton("Memory", loadSpace_ == LoadSpace::Memory)) {

--- a/project/editor/src/UI/View/ConsoleView.cpp
+++ b/project/editor/src/UI/View/ConsoleView.cpp
@@ -14,7 +14,7 @@ using namespace QFE;
  * @brief コンストラクタ
  */
 ConsoleView::ConsoleView() {
-	name_ = "Console View";
+	SetName("Console");
 	isActive_ = true;
 #ifdef QFE_OPTIMIZE_OFF
 	logLevel_ = LogLevel::EditorInfo;
@@ -41,7 +41,7 @@ void ConsoleView::Draw() {
 	if (!isActive_) {
 		return;
 	}
-	ImGui::Begin(name_.c_str(), &isActive_); // Removed &isActive_ from the instruction, but keeping it as the instruction's snippet was partial and this is a common pattern.
+	ImGui::Begin(GetName().c_str(), &isActive_); // Removed &isActive_ from the instruction, but keeping it as the instruction's snippet was partial and this is a common pattern.
 	// フォーカス判定
 	ImGui::Text("Log Level:");
 	ImGui::SameLine();

--- a/project/editor/src/UI/View/EngineProfileView.cpp
+++ b/project/editor/src/UI/View/EngineProfileView.cpp
@@ -10,7 +10,7 @@
 using namespace QFE;
 EngineProfileView::EngineProfileView() {
 	isActive_ = false;
-	name_ = "Engine Profile View";
+	SetName("Engine Profile View");
 }
 
 void EngineProfileView::Initialize() {
@@ -24,7 +24,7 @@ void EngineProfileView::Draw() {
 		return;
 	}
 
-	ImGui::Begin(name_.c_str(), &isActive_, ImGuiWindowFlags_NoDocking);
+	ImGui::Begin(GetName().c_str(), &isActive_, ImGuiWindowFlags_NoDocking);
 	ImGui::Text("Engine Profile");
 	ImGui::Separator();
 	

--- a/project/editor/src/UI/View/GameView.cpp
+++ b/project/editor/src/UI/View/GameView.cpp
@@ -9,7 +9,7 @@
 #include "engine/include/camera/CameraManager.h"
 using namespace QFE;
 GameView::GameView() {
-	name_ = "Game View";
+	SetName("Game View");
 	isActive_ = true;
 	isSceneViewFocused_ = false;
 }
@@ -33,7 +33,7 @@ void GameView::Draw() {
 
 	RenderingPostprocess* render = RenderingPostprocess::GetInstance();
 	DescriptorHandles handle = render->GetCurrentSrvHandle();
-	ImGui::Begin(name_.c_str());
+	ImGui::Begin(GetName().c_str());
 
 	// フォーカス判定
 	isSceneViewFocused_ = ImGui::IsWindowFocused(ImGuiFocusedFlags_RootAndChildWindows);

--- a/project/editor/src/UI/View/HierarchyView.cpp
+++ b/project/editor/src/UI/View/HierarchyView.cpp
@@ -17,7 +17,7 @@ uint32_t HierarchyView::selectedEntityId_ = 0;
 
 HierarchyView::HierarchyView() {
 	isActive_ = true;
-	name_ = "Hierarchy View";
+	SetName("Hierarchy");
 #ifdef QFE_OPTIMIZE_OFF
 	particleCount_ = 1;
 #endif // _DEBUG
@@ -49,7 +49,7 @@ void HierarchyView::Draw() {
 		return;
 	}
 
-	ImGui::Begin(name_.c_str(), &isActive_, ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoScrollbar);
+	ImGui::Begin(GetName().c_str(), &isActive_, ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoScrollbar);
 	// 右クリックでコンテキストメニュー
 	DrawPopupContextWindow();
 	// Entity一覧表示

--- a/project/editor/src/UI/View/InputDebugView.cpp
+++ b/project/editor/src/UI/View/InputDebugView.cpp
@@ -11,7 +11,7 @@ using namespace QFE;
 InputDebugView::InputDebugView()
 {
 	isActive_ = false;
-	name_ = "Input Debug View";
+	SetName("Input Debug View");
 }
 void InputDebugView::Initialize()
 {
@@ -25,7 +25,7 @@ void InputDebugView::Update()
 void InputDebugView::Draw()
 {
     if (!isActive_) { return; }
-	ImGui::Begin("Input Debug View", &isActive_);
+	ImGui::Begin(GetName().c_str(), &isActive_);
     if (ImGui::CollapsingHeader("Mic State View", ImGuiTreeNodeFlags_DefaultOpen)) {
         InputInterface* input = InputInterface::GetInstance();
         if (input->GetMicrophoneDevice().IsCapturing()) {

--- a/project/editor/src/UI/View/InputLogView.cpp
+++ b/project/editor/src/UI/View/InputLogView.cpp
@@ -10,7 +10,7 @@ using namespace QFE;
 InputLogView::InputLogView()
 {
 	isActive_ = false;
-	name_ = "Input Log View";
+	SetName("Input Log View");
 }
 
 void InputLogView::Initialize()
@@ -26,7 +26,7 @@ void InputLogView::Draw()
 	if (!isActive_) { return; }
 	InputInterface* input = InputInterface::GetInstance();
 
-	ImGui::Begin("Input Log View", &isActive_);
+	ImGui::Begin(GetName().c_str(), &isActive_);
 	// キーの録画・停止のコントロール
 	if (input->GetInputLogger().IsRecording()) {
 		if (ImGui::Button("Stop Recording"))

--- a/project/editor/src/UI/View/InspectorView.cpp
+++ b/project/editor/src/UI/View/InspectorView.cpp
@@ -13,7 +13,7 @@ using namespace QFE;
 
 InspectorView::InspectorView() {
 	isActive_ = true;
-	name_ = "Inspector View";
+	SetName("Inspector");
 	selectedEntityId_ = 0;
 
 	if (EditorEngineBridge::GetEntityTemplateDirectoryPath) {
@@ -39,7 +39,7 @@ void InspectorView::Draw() {
 		return;
 	}
 
-	ImGui::Begin(name_.c_str(), &isActive_, ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoScrollbar);
+	ImGui::Begin(GetName().c_str(), &isActive_, ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoScrollbar);
 	// オブジェクトの名前
 	if (EditorEngineBridge::HasComponent(selectedEntityId_, ComponentType::SceneObjectData)) {
 		std::string name = EditorEngineBridge::GetEntityName(selectedEntityId_);

--- a/project/editor/src/UI/View/SceneProfileView.cpp
+++ b/project/editor/src/UI/View/SceneProfileView.cpp
@@ -15,7 +15,7 @@
 
 using namespace QFE;
 SceneProfileView::SceneProfileView() {
-	name_ = "Scene Profile";
+	SetName("Scene Profile");
 	isActive_ = false;
 }
 
@@ -32,7 +32,7 @@ void SceneProfileView::Draw() {
 #ifdef QFE_OPTIMIZE_OFF
 	SceneManager* sceneManager = SceneManager::GetInstance();
 	EntityManager* entityManager = SceneManager::GetInstance()->GetEntityManager();
-	ImGui::Begin("Scene Profile", &isActive_, ImGuiWindowFlags_AlwaysAutoResize);
+	ImGui::Begin(GetName().c_str(), &isActive_, ImGuiWindowFlags_AlwaysAutoResize);
 	ImGui::Separator();
 	ImGui::Text("Active Entities: %zu", entityManager->GetActiveEntityIds().size());
 	ImGui::Separator();

--- a/project/editor/src/UI/View/SceneView.cpp
+++ b/project/editor/src/UI/View/SceneView.cpp
@@ -20,7 +20,7 @@
 #include <algorithm>
 using namespace QFE;
 SceneView::SceneView() {
-	name_ = "Scene View";
+	SetName("Scene View");
 	isActiveCamera_ = true;
 	isDrawGrid_ = true;
 
@@ -52,7 +52,7 @@ void SceneView::Draw() {
 #ifdef QFE_OPTIMIZE_OFF
 	RenderingPostprocess* render = RenderingPostprocess::GetInstance();
 	DescriptorHandles handle = render->GetCurrentSrvHandle();
-	ImGui::Begin("Scene View");
+	ImGui::Begin(GetName().c_str());
 
 	// フォーカス判定
 	bool isSceneViewFocused = ImGui::IsWindowFocused(ImGuiFocusedFlags_RootAndChildWindows);

--- a/project/editor/src/UI/View/ScriptLoggerView.cpp
+++ b/project/editor/src/UI/View/ScriptLoggerView.cpp
@@ -13,7 +13,7 @@ using namespace QFE;
 
 ScriptLoggerView::ScriptLoggerView() {
 	isActive_ = true;
-	name_ = "Script Logger View";
+	SetName("Script Logger");
 	selectedEntityId_ = 0;
 }
 
@@ -29,7 +29,7 @@ void ScriptLoggerView::Draw() {
 	if (!isActive_) {
 		return;
 	}
-	ImGui::Begin(name_.c_str(), &isActive_, ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoScrollbar);
+	ImGui::Begin(GetName().c_str(), &isActive_, ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoScrollbar);
 	ImGui::Text("Selected Entity ID: %d", selectedEntityId_);
 	if (ImGui::Button("Clear Logs")) {
 #ifdef QFE_OPTIMIZE_OFF

--- a/project/engine/BuildInfo.h
+++ b/project/engine/BuildInfo.h
@@ -1,5 +1,5 @@
 #pragma once 
-#define BUILD_COMMIT "f4dbae7c" 
-#define BUILD_BRANCH "develop" 
-#define BUILD_DATE "2026/02/26" 
-#define BUILD_TIME "23:21:30.26" 
+#define BUILD_COMMIT "27a653f8" 
+#define BUILD_BRANCH "refacter-EditorUI" 
+#define BUILD_DATE "2026/03/27" 
+#define BUILD_TIME "10:40:37.39" 

--- a/project/engine/src/assets/Script/CsharpScriptExecutor.cpp
+++ b/project/engine/src/assets/Script/CsharpScriptExecutor.cpp
@@ -29,6 +29,9 @@ void CsharpScriptExecutor::Initialize(EntityManager* entityManager) {
 
 	// このシーン専用のAppDomainを作成
 	MonoDomain* rootDomain = MonoRuntimeManager::GetInstance()->GetRootDomain();
+	rootDomain = mono_domain_get();
+	// TODO: ドメイン名はユニークにする必要があるかもしれない。将来的にはシーンIDを含めるなどの工夫が必要かも。
+
 
 	char domainName[] = "QuickForgeSceneDomain";
 	domain_ = mono_domain_create_appdomain(domainName, nullptr);

--- a/project/engine/src/assets/Script/LuaScriptOnQFE.cpp
+++ b/project/engine/src/assets/Script/LuaScriptOnQFE.cpp
@@ -62,6 +62,8 @@ void LuaScriptOnQFE::LoadScript(const std::string& scriptName) {
 		sol::table env_table = luaState_->create_table();
 		sol::table mt = luaState_->create_table();
 		mt["__index"] = [this](sol::table t, sol::object key) -> sol::object {
+			t;// TODO: 使っていない変数
+
 			if (key.is<std::string>()) {
 				std::string k = key.as<std::string>();
 				auto* em = entityManager_;

--- a/project/engine/src/assets/Script/QFElinker/LuaScriptOnQFESetSubModuleBase.cpp
+++ b/project/engine/src/assets/Script/QFElinker/LuaScriptOnQFESetSubModuleBase.cpp
@@ -6,6 +6,8 @@
 #include "engine/include/core/Entity/EntityManager.h"
 
 void QFE::Script::Base::LuaScriptOnQFESetSubModuleBase(sol::state* luaState, EntityManager* entityManager) {
+	entityManager;// TODO: 使っていない変数
+
 	sol::table qfe = luaState->get<sol::table>("QFE");
 	sol::table input = qfe.create_named("Input");
 	sol::table audio = qfe.create_named("Audio");

--- a/project/engine/src/core/Bridge/EditorEngineBridgeRegistry.cpp
+++ b/project/engine/src/core/Bridge/EditorEngineBridgeRegistry.cpp
@@ -403,6 +403,7 @@ void QFE::EditorEngineBridgeRegistry::RegisterFunctions(WindowsEngineCore* engin
 		};
 
 	EditorEngineBridge::SetLuaScriptParam = [engineCore](uint32_t entityId, uint32_t handle, const std::string& paramName, const std::string& value) {
+		entityId; // TODO: 現状、handleでスクリプトを特定しているためentityIdは使用しないが、将来的に複数スクリプトを同一エンティティにアタッチできるようになった際に必要になる可能性があるため引数として残す
 		SceneManager* sceneManager_ = engineCore->GetSceneManager();
 		if (sceneManager_) {
 			LuaScriptOnQFE* script = sceneManager_->GetLuaScriptExecutor()->GetScript(handle);
@@ -440,6 +441,7 @@ void QFE::EditorEngineBridgeRegistry::RegisterFunctions(WindowsEngineCore* engin
 		};
 
 	EditorEngineBridge::RemoveCsharpScript = [engineCore](uint32_t entityId, const std::string& className) {
+		className; // TODO: 現状、C#スクリプトはクラス名で特定しているためentityIdは使用しないが、将来的に複数スクリプトを同一エンティティにアタッチできるようになった際に必要になる可能性があるため引数として残す
 		SceneManager* sceneManager_ = engineCore->GetSceneManager();
 		if (sceneManager_) {
 			sceneManager_->GetEntityManager()->RemoveComponent<CsharpComponent>(entityId);


### PR DESCRIPTION
IEditorUIにSetNameを追加し、UI名管理をアクセサ経由に統一しました。各UIクラスでのname_直接代入を廃止し、ImGuiウィンドウ名指定もGetName()利用に変更。未使用引数へのダミー参照やコメント追加、Monoドメイン初期化の明示化、ビルド情報の更新も含みます。これにより保守性・拡張性・可読性が向上しています。

変更をEditorUIだけに収めようとしたが、ビルド時にエラーを吐くので一旦そのほかもいじった。TODOとしてコメントアウトしている