### PR TITLE
Luncher→launcherへリネーム等の修正と設定ファイル修正

### DIFF
--- a/project/.editorconfig
+++ b/project/.editorconfig
@@ -5,6 +5,6 @@ spelling_error_severity = spelling_error_severity
 # チェック対象を識別子とコメントに限定
 spelling_checkable_types = identifiers,comments
 # 辞書を英語限定にする
-spelling_use_default_excusion_dictionary = true
+spelling_use_default_exclusion_dictionary = true
 # 自分の専用除外辞書を指定
 spelling_exclusion_path = ./exclusion.dic

--- a/project/engine/BuildInfo.h
+++ b/project/engine/BuildInfo.h
@@ -1,5 +1,5 @@
 #pragma once 
-#define BUILD_COMMIT "e62c4e2e" 
-#define BUILD_BRANCH "fix-rename" 
-#define BUILD_DATE "2026/04/12" 
-#define BUILD_TIME "14:28:29.51" 
+#define BUILD_COMMIT "bdcd301f" 
+#define BUILD_BRANCH "develop" 
+#define BUILD_DATE "2026/04/13" 
+#define BUILD_TIME "10:57:34.06" 

--- a/project/premake5.lua
+++ b/project/premake5.lua
@@ -158,8 +158,8 @@ group "QuickForge" -- MyMainProject
             }
         filter ""
 
-    project "Luncher" -- Luncher
-        location "luncher"
+    project "launcher" -- Launcher
+        location "launcher"
         kind "StaticLib" 
         language "C++"
         


### PR DESCRIPTION
.editorconfigのスペルミス修正、BuildInfo.hのビルド情報更新、premake5.luaでプロジェクト名とディレクトリ名を"Luncher"から"launcher"へリネームしました。