### PR TITLE
シーン管理に状態遷移を導入し処理を分離

### DIFF
--- a/project/Resources/NewGameProject/Scenes/MainScene.json
+++ b/project/Resources/NewGameProject/Scenes/MainScene.json
@@ -1,0 +1,87 @@
+{
+    "entities": [
+        {
+            "CameraData": {
+                "farZ": 100.0,
+                "fovY": 0.44999998807907104,
+                "nearZ": 0.10000000149011612
+            },
+            "SceneObjectData": {
+                "name": "DebugCamera",
+                "tag": "camera",
+                "uniqueId": 749036978
+            },
+            "Transform": {
+                "rotate": [
+                    0.10000000149011612,
+                    0.0,
+                    0.0
+                ],
+                "scale": [
+                    1.0,
+                    1.0,
+                    1.0
+                ],
+                "translate": [
+                    0.0,
+                    1.5,
+                    -10.0
+                ]
+            }
+        },
+        {
+            "CameraData": {
+                "farZ": 100.0,
+                "fovY": 0.44999998807907104,
+                "nearZ": 0.10000000149011612
+            },
+            "SceneObjectData": {
+                "name": "Camera",
+                "tag": "camera",
+                "uniqueId": 749036979
+            },
+            "Transform": {
+                "rotate": [
+                    0.10000000149011612,
+                    0.0,
+                    0.0
+                ],
+                "scale": [
+                    1.0,
+                    1.0,
+                    1.0
+                ],
+                "translate": [
+                    0.0,
+                    1.5,
+                    -10.0
+                ]
+            }
+        },
+        {
+            "SceneObjectData": {
+                "name": "This is Main",
+                "tag": "Untagged",
+                "uniqueId": 749036980
+            },
+            "Transform": {
+                "rotate": [
+                    0.0,
+                    0.0,
+                    0.0
+                ],
+                "scale": [
+                    1.0,
+                    1.0,
+                    1.0
+                ],
+                "translate": [
+                    0.0,
+                    0.0,
+                    0.0
+                ]
+            }
+        }
+    ],
+    "sceneName": "MainScene"
+}

--- a/project/engine/BuildInfo.h
+++ b/project/engine/BuildInfo.h
@@ -1,5 +1,5 @@
 #pragma once 
-#define BUILD_COMMIT "bdcd301f" 
+#define BUILD_COMMIT "60ffef8e" 
 #define BUILD_BRANCH "develop" 
 #define BUILD_DATE "2026/04/13" 
-#define BUILD_TIME "10:57:34.06" 
+#define BUILD_TIME "12:17:18.26" 

--- a/project/engine/include/scene/Data/SceneState.h
+++ b/project/engine/include/scene/Data/SceneState.h
@@ -1,0 +1,12 @@
+#pragma once
+namespace QFE {
+	/**
+	 * @class SceneState
+	 * @brief シーンの状態を表す列挙型
+	 */
+	enum class SceneState {
+		FirstLoad,		/**< 最初のシーンロード */
+		Running,		/**< シーンが実行中 */
+		Transitioning,	/**< シーン遷移中 */
+	};
+}

--- a/project/engine/include/scene/SceneManager.h
+++ b/project/engine/include/scene/SceneManager.h
@@ -7,6 +7,7 @@
 #include "IScene.h"
 #include "engine/include/utility/DesignPatterns/Singleton.h"
 #include "engine/include/utility/ID/UniqueIDManager.h"
+#include "engine/include/scene/Data/SceneState.h"
 
 #include "engine/include/core/Math/Vector/Vector2.h"
 #include <memory>
@@ -126,14 +127,21 @@ namespace QFE {
 
 	private:
 		int score_;
-		bool isFirstLoadScene_;
-		bool isRequestRunTimeLoadScene_;
 		nlohmann::json sceneConfig_;
 		nlohmann::json sceneGlobalData_;
 		std::unique_ptr<IScene> currentScene_;
 		std::unique_ptr<IScene> nextScene_;
 
 		std::string nextSceneName_;
+
+		SceneState currentSceneState_;
+		std::vector<std::function<void()>> sceneState_;
+		/// @brief はじめのシーンをロード
+		void FirstLoadScene();
+		/// @brief シーンの更新
+		void RunningScene();
+		/// @brief シーンの遷移
+		void TransitioningScene();
 	};
 
 }

--- a/project/engine/src/scene/SceneManager.cpp
+++ b/project/engine/src/scene/SceneManager.cpp
@@ -15,8 +15,10 @@ using namespace QFE;
 void SceneManager::Initialize() {
 	std::chrono::high_resolution_clock::time_point startTime = std::chrono::high_resolution_clock::now();
 
-	isRequestRunTimeLoadScene_ = false;
-	isFirstLoadScene_ = false;
+	// シーンの状態関数を登録
+	sceneState_.push_back([this]() { FirstLoadScene(); });
+	sceneState_.push_back([this]() { RunningScene(); });
+	sceneState_.push_back([this]() { TransitioningScene(); });
 
 	// sceneConfig.jsonを読み込む。存在しない場合は空のJSONオブジェクトを使用
 	sceneConfig_ = nlohmann::json::object();
@@ -51,34 +53,8 @@ void SceneManager::Initialize() {
 void SceneManager::Update() {
 	std::chrono::high_resolution_clock::time_point startTime = std::chrono::high_resolution_clock::now();
 
-	// 最初のシーンロードは、前回終了時のシーンを自動で読み込む。これにより、エディタで作業しているシーンを継続して編集できるようにする。
-	if (!isFirstLoadScene_) {
-		if (sceneConfig_.contains("lastScene")) {
-			try {
-				LoadScene(sceneConfig_["lastScene"].get<std::string>());
-#ifdef QFE_OPTIMIZE_ON
-				StartScript();
-#endif // _RELEASE
-
-			}
-			catch (const std::exception& e) {
-				e;
-#ifdef QFE_OPTIMIZE_OFF
-				DebugLog(std::string("Error: ") + e.what(), LogLevel::EditorInfo);
-#endif // QFE_OPTIMIZE_OFF
-			}
-		}
-		isFirstLoadScene_ = true;
-	}
-
-	if (isRequestRunTimeLoadScene_) {
-		LoadScene(nextSceneName_);
-		StartScript();
-		isRequestRunTimeLoadScene_ = false;
-		nextSceneName_.clear();
-	}
-
-	currentScene_->Update();
+	// 現在のシーン状態に応じた処理を実行
+	sceneState_[static_cast<size_t>(currentSceneState_)]();
 
 	std::chrono::high_resolution_clock::time_point endTime = std::chrono::high_resolution_clock::now();
 #ifdef QFE_OPTIMIZE_OFF
@@ -196,7 +172,7 @@ void SceneManager::ResetScene() {
 
 void SceneManager::RunTimeSwapScene(const std::string& sceneName) {
 	StopScript();
-	isRequestRunTimeLoadScene_ = true;
+	currentSceneState_ = SceneState::Transitioning;
 	nextSceneName_ = sceneName;
 }
 
@@ -284,4 +260,33 @@ void SceneManager::StartScript() {
 
 void SceneManager::StopScript() {
 	currentScene_->StopScene();
+}
+
+void QFE::SceneManager::FirstLoadScene() {
+	if (sceneConfig_.contains("lastScene")) {
+		try {
+			LoadScene(sceneConfig_["lastScene"].get<std::string>());
+#ifdef QFE_OPTIMIZE_ON
+			StartScript();
+#endif // _RELEASE
+		}
+		catch (const std::exception& e) {
+			e;
+#ifdef QFE_OPTIMIZE_OFF
+			DebugLog(std::string("Error: ") + e.what(), LogLevel::EditorInfo);
+#endif // QFE_OPTIMIZE_OFF
+		}
+	}
+	currentSceneState_ = SceneState::Running;
+}
+
+void QFE::SceneManager::RunningScene() {
+	currentScene_->Update();
+}
+
+void QFE::SceneManager::TransitioningScene() {
+	LoadScene(nextSceneName_);
+	StartScript();
+	currentSceneState_ = SceneState::Running;
+	nextSceneName_.clear();
 }


### PR DESCRIPTION
SceneState列挙型を新規追加し、SceneManagerのシーン状態管理をFirstLoad/Running/Transitioningで明確化。Update処理を状態ごとに関数分割し、旧フラグ管理を廃止。シーン遷移要求時の挙動も状態遷移で統一。MainScene.jsonにカメラ2台とSceneObjectを追加。ビルド情報も更新。