### PR TITLE
VariableLengthPoolでemplace_backをpush_backに変更

### DIFF
--- a/project/engine/include/utility/memory/VariableLengthPool.h
+++ b/project/engine/include/utility/memory/VariableLengthPool.h
@@ -49,7 +49,7 @@ namespace QFE {
 		T* Acquire() {
 			if (freeIndices_.empty()) {
 				size_t newIndex = pool_.size();
-				pool_.emplace_back();
+				pool_.push_back(T());
 				return &pool_[newIndex];
 			} else {
 				size_t index = freeIndices_.top();


### PR DESCRIPTION
pool_への要素追加時にemplace_back()からpush_back(T())へ変更しました。これにより、デフォルト構築されたT型オブジェクトを一度生成してからプールに追加する動作となります。型の要件やパフォーマンスに影響する可能性があります。