### PR TITLE
filePathLiblary_のスペルミスをfilePathLibrary_に修正

### DIFF
--- a/project/engine/include/assets/2DTexture/TextureManager.h
+++ b/project/engine/include/assets/2DTexture/TextureManager.h
@@ -78,14 +78,16 @@ namespace QFE {
 		D3D12_HEAP_PROPERTIES heapProperties_;
 		D3D12_RESOURCE_DESC resourceDesc_;
 
+		// 画像一枚のリソースたち
 		SafeVector<D3D12_CPU_DESCRIPTOR_HANDLE> textureSrvHandleCPU_;
 		SafeVector<D3D12_GPU_DESCRIPTOR_HANDLE> textureSrvHandleGPU_;
 		SafeVector<Microsoft::WRL::ComPtr<ID3D12Resource>> textureResources_;
 		SafeVector<std::unique_ptr<DirectX::ScratchImage>> scratchImages_;
 
+		// ファイルパスとハンドルの対応を管理するためのライブラリ
 		int32_t textureHandle_;
 		SafeVector<Microsoft::WRL::ComPtr<ID3D12Resource>> intermediateResource_;
-		StringLibrary filePathLiblary_;
+		StringLibrary filePathLibrary_;
 	};
 
 }

--- a/project/engine/src/assets/2DTexture/TextureManager.cpp
+++ b/project/engine/src/assets/2DTexture/TextureManager.cpp
@@ -58,7 +58,7 @@ void TextureManager::Initialize(ID3D12Device* device, ID3D12GraphicsCommandList*
 	textureResources_.clear();
 	scratchImages_.clear();
 	intermediateResource_.clear();
-	filePathLiblary_.Init("TextureFileName");
+	filePathLibrary_.Init("TextureFileName");
 
 	textureHandle_ = 0;
 }
@@ -235,7 +235,7 @@ int32_t TextureManager::LoadTexture(const std::string& filePath) {
 #endif // QFE_OPTIMIZE_OFF
 
 	// 陷ｷ蠕個ｧ騾包ｽｻ陷剃ｸ翫Ψ郢ｧ・｡郢ｧ・､郢晢ｽｫ郢ｧ螳夲ｽｪ・ｭ邵ｺ・ｿ髴趣ｽｼ邵ｺ・ｾ邵ｺ・ｪ邵ｺ繝ｻ
-	int32_t fileIndex = filePathLiblary_.GetLibraryIndex(filePath);
+	int32_t fileIndex = filePathLibrary_.GetLibraryIndex(filePath);
 	if (fileIndex >= 0) {
 #ifdef QFE_OPTIMIZE_OFF
 		DebugLog(ConvertString(std::format(L"TextureManager: LoadedTheSameFile->return {}", fileIndex)));
@@ -262,7 +262,7 @@ int32_t TextureManager::LoadTexture(const std::string& filePath) {
 #ifdef QFE_OPTIMIZE_OFF
 	DebugLog(ConvertString(std::format(L"TextureManager: whidth={},height={},return->{}", metadata.width, metadata.height, textureHandle_ - 1)));
 #endif // QFE_OPTIMIZE_OFF
-	filePathLiblary_.AddStringToLibrary(filePath);
+	filePathLibrary_.AddStringToLibrary(filePath);
 	return textureHandle_ - 1;
 }
 


### PR DESCRIPTION
- TextureManagerクラス内のfilePathLiblary_をfilePathLibrary_にリネーム
- TextureManager.hおよびTextureManager.cppの該当箇所をすべて修正
- 機能的な変更はなく、可読性・保守性向上のためのリファクタリング