### PR TITLE
デバッグログ出力をQFE_LOGマクロで統一・最適化

### DIFF
--- a/project/engine/BuildInfo.h
+++ b/project/engine/BuildInfo.h
@@ -1,5 +1,5 @@
 #pragma once 
-#define BUILD_COMMIT "f1df83d7" 
+#define BUILD_COMMIT "ea0c8183" 
 #define BUILD_BRANCH "develop" 
-#define BUILD_DATE "2026/04/25" 
-#define BUILD_TIME "20:17:23.23" 
+#define BUILD_DATE "2026/04/26" 
+#define BUILD_TIME "23:09:50.11" 

--- a/project/engine/include/core/Memory/SafeVector.h
+++ b/project/engine/include/core/Memory/SafeVector.h
@@ -18,7 +18,7 @@ namespace QFE {
 			// std::vectorで確保できるサイズを超えている場合は例外を投げる
 			if (size > data_.max_size()) {
 #ifdef QFE_OPTIMIZE_OFF
-				DebugLog(std::string("Data MaxSize: ") + std::to_string(data_.max_size()));
+				QFE_LOG(std::string("Data MaxSize: ") + std::to_string(data_.max_size()));
 #endif // QFE_OPTIMIZE_OFF
 				throw std::length_error("SafeVector size exceeds maximum allowed by std::vector.");
 			}
@@ -26,7 +26,7 @@ namespace QFE {
 			data_.clear();
 			data_.reserve(size);
 #ifdef QFE_OPTIMIZE_OFF
-			DebugLog(std::string("SafeVector initialized with reserved size: ") + std::to_string(size));
+			QFE_LOG(std::string("SafeVector initialized with reserved size: ") + std::to_string(size));
 #endif // QFE_OPTIMIZE_OFF
 		}
 

--- a/project/engine/include/utility/DebugTool/DebugLog/MyDebugLog.h
+++ b/project/engine/include/utility/DebugTool/DebugLog/MyDebugLog.h
@@ -55,12 +55,18 @@ namespace QFE {
 
 	};
 
-	/// <summary>
-	/// 縺薙・繝倥ャ繝€繝ｼ繧定ｪｭ縺ｿ霎ｼ繧薙〒縺・ｌ縺ｰ菴ｿ縺医ｋ繧・▽
-	/// </summary>
-	/// <param name="message"></param>
+	/// @brief ログを出力する関数. 最適化オフのときのみ有効.
+	/// これ自体を呼び出すときは、QFE_LOGマクロを使用してください.ifdefを毎度書く必要がなくなります.
 	void DebugLog(const std::string& message, const LogLevel& logLevel = LogLevel::EngineInfo, const std::source_location& location = std::source_location::current());
 
+	/// @brief C#側から呼び出すためのログ出力関数. 最適化オフのときのみ有効.
 	void DebugLogCsharp(const std::string& message);
+
+	// 最適化オフのときのみログを出力するマクロ. 最適化オンのときは何もしない.
+#ifdef QFE_OPTIMIZE_OFF
+#define QFE_LOG(...) DebugLog(__VA_ARGS__)
+#else
+#define QFE_LOG(...) ((void)0)
+#endif
 
 }

--- a/project/engine/src/WindowsEngineCore.cpp
+++ b/project/engine/src/WindowsEngineCore.cpp
@@ -63,7 +63,7 @@ void QFE::WindowsEngineCore::Initialize(std::unique_ptr<IEngineApp> app) {
 	MyDebugLog::GetInstance()->Initialize();
 	// キャッシュラインサイズのログを出力
 	std::string logInitMessage = "Initialized MyDebugLog. Cache line size: " + std::to_string(std::hardware_destructive_interference_size) + " bytes.";
-	DebugLog(logInitMessage);
+	QFE_LOG(logInitMessage);
 #endif // QFE_OPTIMIZE_OFF
 
 	// Create Window
@@ -126,13 +126,13 @@ void QFE::WindowsEngineCore::Initialize(std::unique_ptr<IEngineApp> app) {
 		if (assetManager_->GetResourceDirectoryManager()->CheckDirectoryIntegrity() == false) {
 			assetManager_->GetResourceDirectoryManager()->RepairDirectoryIntegrity();
 #ifdef QFE_OPTIMIZE_OFF
-			DebugLog("Repaired project directory integrity");
+			QFE_LOG("Repaired project directory integrity");
 #endif // QFE_OPTIMIZE_OFF
 		}
 		assetManager_->GetResourceDirectoryManager()->SetProjectDirectory(configJson_["lastProjectName"]);
 	} else {
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog("No last project name found, creating a new project directory");
+		QFE_LOG("No last project name found, creating a new project directory");
 #endif // QFE_OPTIMIZE_OFF
 		// 最後に開いたプロジェクトの名前が保存されていない場合は、新しいプロジェクトのディレクトリを生成して設定する
 		std::string defaultProjectName = "NewGameProject";
@@ -155,7 +155,7 @@ void QFE::WindowsEngineCore::Initialize(std::unique_ptr<IEngineApp> app) {
 	engineApp_->Initialize();
 
 #ifdef QFE_OPTIMIZE_OFF
-	DebugLog("======================Initialized OnWindowsEditor======================");
+	QFE_LOG("======================Initialized OnWindowsEditor======================");
 #endif // QFE_OPTIMIZE_OFF
 
 	frameCounter_.Initialize();
@@ -163,7 +163,7 @@ void QFE::WindowsEngineCore::Initialize(std::unique_ptr<IEngineApp> app) {
 	graphRenderer_->Initialize();
 
 #ifdef QFE_OPTIMIZE_OFF
-	DebugLog("======================InitializedGraphRenderer======================");
+	QFE_LOG("======================InitializedGraphRenderer======================");
 #endif // QFE_OPTIMIZE_OFF
 
 	inputInterface_ = InputInterface::GetInstance();
@@ -171,35 +171,35 @@ void QFE::WindowsEngineCore::Initialize(std::unique_ptr<IEngineApp> app) {
 		dynamic_cast<GameWindowManager*>(gameWindowManager.get())->GetWindow(windowTitle), hInstance_);
 
 #ifdef QFE_OPTIMIZE_OFF
-	DebugLog("======================Initialized InputInterface======================");
+	QFE_LOG("======================Initialized InputInterface======================");
 #endif // QFE_OPTIMIZE_OFF
 
 	sceneManager_ = SceneManager::GetInstance();
 	sceneManager_->Initialize();
 
 #ifdef QFE_OPTIMIZE_OFF
-	DebugLog("======================Initialized SceneManager======================");
+	QFE_LOG("======================Initialized SceneManager======================");
 #endif // QFE_OPTIMIZE_OFF
 
 	physicsManager_ = PhysicsManager::GetInstance();
 	physicsManager_->Initialize();
 
 #ifdef QFE_OPTIMIZE_OFF
-	DebugLog("======================Initialized PhysicsManager======================");
+	QFE_LOG("======================Initialized PhysicsManager======================");
 #endif // QFE_OPTIMIZE_OFF
 
 	colliderManager_ = ColliderManager::GetInstance();
 	colliderManager_->Initialize();
 
 #ifdef QFE_OPTIMIZE_OFF
-	DebugLog("======================Initialized ColliderManager======================");
+	QFE_LOG("======================Initialized ColliderManager======================");
 #endif // QFE_OPTIMIZE_OFF
 
 	audioInterface_ = AudioInterface::GetInstance();
 	audioInterface_->Initialize();
 
 #ifdef QFE_OPTIMIZE_OFF
-	DebugLog("======================Initialized Engine======================");
+	QFE_LOG("======================Initialized Engine======================");
 #endif // QFE_OPTIMIZE_OFF
 }
 
@@ -229,7 +229,7 @@ void WindowsEngineCore::Shutdown() {
 	EditorEngineBridgeRegistry::ClearFunctions();
 	// エンジンの設定ファイルに最後に開いたプロジェクトの名前を保存する
 #ifdef QFE_OPTIMIZE_OFF
-	DebugLog("Shutdown Engine");
+	QFE_LOG("Shutdown Engine");
 	configJson_["lastProjectName"] = assetManager_->GetResourceDirectoryManager()->GetProjectName();
 	QFE::FILE::SaveJSONToFile(configFilePath_, configJson_);
 #endif // QFE_OPTIMIZE_OFF
@@ -261,7 +261,7 @@ void WindowsEngineCore::Shutdown() {
 	directXCommon_->Shutdown();
 	gameWindowManager->Shutdown();
 #ifdef QFE_OPTIMIZE_OFF
-	DebugLog("FinalizeEngine");
+	QFE_LOG("FinalizeEngine");
 	MyDebugLog::GetInstance()->Finalize();
 #endif // QFE_OPTIMIZE_OFF
 }

--- a/project/engine/src/assets/2DTexture/TextureManager.cpp
+++ b/project/engine/src/assets/2DTexture/TextureManager.cpp
@@ -104,8 +104,8 @@ void TextureManager::LoadScratchImage(const std::string& filePath) {
 
 #ifdef QFE_OPTIMIZE_OFF
 	const DirectX::TexMetadata& metadata = image.GetMetadata();
-	DebugLog(std::format("TextureManager: Loaded texture from '{}'", filePath));
-	DebugLog(ConvertString(std::format(L"TextureManager: whidth={},height={},arraySize={}", metadata.width, metadata.height, metadata.arraySize)));
+	QFE_LOG(std::format("TextureManager: Loaded texture from '{}'", filePath));
+	QFE_LOG(ConvertString(std::format(L"TextureManager: whidth={},height={},arraySize={}", metadata.width, metadata.height, metadata.arraySize)));
 #endif // QFE_OPTIMIZE_OFF
 
 	// ミップマップの生成
@@ -144,7 +144,7 @@ Microsoft::WRL::ComPtr<ID3D12Resource> TextureManager::CreateTextureResource(con
 	// メタデータの整合性を確認
 	if (resourceDesc_.Width == 0 || resourceDesc_.Height == 0 || resourceDesc_.MipLevels == 0 || resourceDesc_.DepthOrArraySize == 0) {
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog(std::format("TextureManager: Invalid texture metadata - width={}, height={}, mipLevels={}, arraySize={}", resourceDesc_.Width, resourceDesc_.Height, resourceDesc_.MipLevels, resourceDesc_.DepthOrArraySize));
+		QFE_LOG(std::format("TextureManager: Invalid texture metadata - width={}, height={}, mipLevels={}, arraySize={}", resourceDesc_.Width, resourceDesc_.Height, resourceDesc_.MipLevels, resourceDesc_.DepthOrArraySize));
 #endif // QFE_OPTIMIZE_OFF
 		throw std::runtime_error("Invalid texture metadata.");
 	}
@@ -231,14 +231,14 @@ void TextureManager::ReleaseIntermediateResources() {
 int32_t TextureManager::LoadTexture(const std::string& filePath) {
 	// 郢晁ｼ斐＜郢ｧ・､郢晢ｽｫ郢昜ｻ｣縺幃勗・ｨ驕会ｽｺ
 #ifdef QFE_OPTIMIZE_OFF
-	DebugLog(std::format("TextureManager: LoadPath {}", filePath));
+	QFE_LOG(std::format("TextureManager: LoadPath {}", filePath));
 #endif // QFE_OPTIMIZE_OFF
 
 	// 陷ｷ蠕個ｧ騾包ｽｻ陷剃ｸ翫Ψ郢ｧ・｡郢ｧ・､郢晢ｽｫ郢ｧ螳夲ｽｪ・ｭ邵ｺ・ｿ髴趣ｽｼ邵ｺ・ｾ邵ｺ・ｪ邵ｺ繝ｻ
 	int32_t fileIndex = filePathLibrary_.GetLibraryIndex(filePath);
 	if (fileIndex >= 0) {
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog(ConvertString(std::format(L"TextureManager: LoadedTheSameFile->return {}", fileIndex)));
+		QFE_LOG(ConvertString(std::format(L"TextureManager: LoadedTheSameFile->return {}", fileIndex)));
 #endif // QFE_OPTIMIZE_OFF
 		return fileIndex;
 	}
@@ -252,7 +252,7 @@ int32_t TextureManager::LoadTexture(const std::string& filePath) {
 	if (resource) {
 		D3D12_RESOURCE_DESC desc = resource->GetDesc();
 		D3D12_RESOURCE_ALLOCATION_INFO allocInfo = device_->GetResourceAllocationInfo(0, 1, &desc);
-		DebugLog(std::format("ResourceSize: {}byte", allocInfo.SizeInBytes));
+		QFE_LOG(std::format("ResourceSize: {}byte", allocInfo.SizeInBytes));
 	}
 #endif // QFE_OPTIMIZE_OFF
 	CreateShaderResourceView(metadata, textureResources_.back().Get());
@@ -260,7 +260,7 @@ int32_t TextureManager::LoadTexture(const std::string& filePath) {
 	intermediateResource_.push_back(
 		UploadTextureData(textureResources_.back().Get(), *(scratchImages_.back().get()), commandList_));
 #ifdef QFE_OPTIMIZE_OFF
-	DebugLog(ConvertString(std::format(L"TextureManager: whidth={},height={},return->{}", metadata.width, metadata.height, textureHandle_ - 1)));
+	QFE_LOG(ConvertString(std::format(L"TextureManager: whidth={},height={},return->{}", metadata.width, metadata.height, textureHandle_ - 1)));
 #endif // QFE_OPTIMIZE_OFF
 	filePathLibrary_.AddStringToLibrary(filePath);
 	return textureHandle_ - 1;
@@ -269,7 +269,7 @@ int32_t TextureManager::LoadTexture(const std::string& filePath) {
 Vector2 TextureManager::GetTextureSize(int32_t textureHandle) {
 	if (textureHandle < 0 || textureHandle >= static_cast<int32_t>(textureResources_.size())) {
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog("TextureManager: Invalid texture handle");
+		QFE_LOG("TextureManager: Invalid texture handle");
 #endif // QFE_OPTIMIZE_OFF
 		return Vector2(0.0f, 0.0f);
 	}

--- a/project/engine/src/assets/3DModel/Loader/AssimpModelLoader.cpp
+++ b/project/engine/src/assets/3DModel/Loader/AssimpModelLoader.cpp
@@ -18,7 +18,7 @@ void AssimpModelLoader::LoadModelData(const std::string& modelResourceDirectory,
 	// ファイルの存在確認
 	if (!QFE::FILE::HasFile(filepath)) {
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog(std::format("Model file not found: {}", filepath));
+		QFE_LOG(std::format("Model file not found: {}", filepath));
 #endif // QFE_OPTIMIZE_OFF
 		assert(false && "Model file not found");
 		return;
@@ -27,7 +27,7 @@ void AssimpModelLoader::LoadModelData(const std::string& modelResourceDirectory,
 	// Obj形式である場合、mtlもあるか確認する
 	if (!QFE::FILE::HasObjModelFiles(modelResourceDirectory, filename)) {
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog(std::format("MTL file not found for OBJ model: {}", filename));
+		QFE_LOG(std::format("MTL file not found for OBJ model: {}", filename));
 #endif // QFE_OPTIMIZE_OFF
 		assert(false && "MTL file not found for OBJ model");
 		throw std::runtime_error("MTL file not found for OBJ model: " + filename);
@@ -45,17 +45,17 @@ void AssimpModelLoader::LoadModelData(const std::string& modelResourceDirectory,
 	}
 
 #ifdef QFE_OPTIMIZE_OFF
-	DebugLog(std::format("Model Load Success: {}", filepath));
+	QFE_LOG(std::format("Model Load Success: {}", filepath));
 #endif // QFE_OPTIMIZE_OFF
 
 	for (unsigned int meshIdx = 0; meshIdx < scene->mNumMeshes; ++meshIdx) {
 		const aiMesh* mesh = scene->mMeshes[meshIdx];
 
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog(std::format("Loading Mesh {} / {}", meshIdx + 1, scene->mNumMeshes));
-		DebugLog(std::format("UVChannel: {}", mesh->GetNumUVChannels()));
-		DebugLog(std::format("ColorChannel: {}", mesh->GetNumColorChannels()));
-		DebugLog(std::format("NumUVComponents for channel 0: {}", mesh->mNumUVComponents[0]));
+		QFE_LOG(std::format("Loading Mesh {} / {}", meshIdx + 1, scene->mNumMeshes));
+		QFE_LOG(std::format("UVChannel: {}", mesh->GetNumUVChannels()));
+		QFE_LOG(std::format("ColorChannel: {}", mesh->GetNumColorChannels()));
+		QFE_LOG(std::format("NumUVComponents for channel 0: {}", mesh->mNumUVComponents[0]));
 #endif // QFE_OPTIMIZE_OFF
 
 		// 頂点データの読み込み
@@ -110,13 +110,13 @@ void AssimpModelLoader::LoadModelData(const std::string& modelResourceDirectory,
 			if (material->GetTexture(aiTextureType_DIFFUSE, 0, &texPath) == AI_SUCCESS) {
 				meshData.material.textureFilePath = imageResourceDirectory + std::string(texPath.C_Str());
 #ifdef QFE_OPTIMIZE_OFF
-				DebugLog(std::format("Loaded diffuse texture for mesh {}: {}", meshIdx, meshData.material.textureFilePath));
+				QFE_LOG(std::format("Loaded diffuse texture for mesh {}: {}", meshIdx, meshData.material.textureFilePath));
 #endif // QFE_OPTIMIZE_OFF
 
 			} else {
 				meshData.material.textureFilePath = "";
 #ifdef QFE_OPTIMIZE_OFF
-				DebugLog(std::format("No diffuse texture found for mesh {}. Setting empty texture path.", meshIdx));
+				QFE_LOG(std::format("No diffuse texture found for mesh {}. Setting empty texture path.", meshIdx));
 #endif // QFE_OPTIMIZE_OFF
 			}
 		}

--- a/project/engine/src/assets/Animator/AnimClip.cpp
+++ b/project/engine/src/assets/Animator/AnimClip.cpp
@@ -36,7 +36,7 @@ Transform AnimClip::GetTransformAtTime(float time) const {
 	// キーフレームが存在しない場合はデフォルトのTransformを返す
 	if (keyframes_.empty()) {
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog("GetTransformAtTime: No keyframes available.");
+		QFE_LOG("GetTransformAtTime: No keyframes available.");
 #endif // QFE_OPTIMIZE_OFF
 		return result;
 	}

--- a/project/engine/src/assets/AssetManager.cpp
+++ b/project/engine/src/assets/AssetManager.cpp
@@ -70,7 +70,7 @@ uint32_t AssetManager::LoadModel(const std::string& modelName) {
 		// テクスチャファイルパスが空の場合は読み込めない事にする
 		if (mesh.material.textureFilePath.empty()) {
 #ifdef QFE_OPTIMIZE_OFF
-			DebugLog("Mesh " + mesh.material.textureFilePath + " in model " + modelName + " has no texture file path.", LogLevel::Warning);
+			QFE_LOG("Mesh " + mesh.material.textureFilePath + " in model " + modelName + " has no texture file path.", LogLevel::Warning);
 #endif // QFE_OPTIMIZE_OFF
 			throw std::runtime_error("Mesh " + mesh.material.textureFilePath + " in model " + modelName + " has no texture file path.");
 		}

--- a/project/engine/src/assets/AudioSource/AudioSourceManager.cpp
+++ b/project/engine/src/assets/AudioSource/AudioSourceManager.cpp
@@ -25,13 +25,13 @@ uint32_t AudioSourceManager::LoadSoundData(const std::string& filePath) {
 	AudioData soundData;
 	try{
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog("LoadSoundData: " + filePath);
+		QFE_LOG("LoadSoundData: " + filePath);
 #endif // QFE_OPTIMIZE_OFF
 		soundData = Multiaudioloader::LoadAudioData(filePath);
 	}
 	catch (const std::exception& e){
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog("Faild LoadSoundData: " + filePath);
+		QFE_LOG("Faild LoadSoundData: " + filePath);
 #endif // QFE_OPTIMIZE_OFF
 		e;
 		return 0;
@@ -45,7 +45,7 @@ uint32_t AudioSourceManager::LoadSoundData(const std::string& filePath) {
 
 AudioData& AudioSourceManager::GetSoundData(uint32_t handle) {
 #ifdef QFE_OPTIMIZE_OFF
-	DebugLog("GetSoundData: " + std::to_string(handle));
+	QFE_LOG("GetSoundData: " + std::to_string(handle));
 #endif // QFE_OPTIMIZE_OFF
 	if (audioDataMap_.find(handle) == audioDataMap_.end()) {
 		assert(false && "Invalid handle");

--- a/project/engine/src/assets/ResourceDirectoryManager.cpp
+++ b/project/engine/src/assets/ResourceDirectoryManager.cpp
@@ -34,7 +34,7 @@ ResourceDirectoryManager::ResourceDirectoryManager() {
 
 #ifdef QFE_OPTIMIZE_OFF
 	for (const auto& [key, value] : resourceDirectories_) {
-		DebugLog(std::format("Key: {},Directory: {}", key, value));
+		QFE_LOG(std::format("Key: {},Directory: {}", key, value));
 	}
 #endif // QFE_OPTIMIZE_OFF
 
@@ -67,7 +67,7 @@ std::string ResourceDirectoryManager::GetResourceDirectory(const std::string& re
 	std::string directory = rootDirectory_ + ProjectName_ + "/" + resourceDirectories_.at(resourceType);
 
 #ifdef QFE_OPTIMIZE_OFF
-	DebugLog(std::format("GetResourceDirectory: ResourceType: {}, Directory: {}", resourceType, directory));
+	QFE_LOG(std::format("GetResourceDirectory: ResourceType: {}, Directory: {}", resourceType, directory));
 #endif // QFE_OPTIMIZE_OFF
 
 	// ディレクトリが存在しない場合は作成する

--- a/project/engine/src/assets/Script/CsharpCompiler.cpp
+++ b/project/engine/src/assets/Script/CsharpCompiler.cpp
@@ -64,8 +64,8 @@ void QFE::CompileCSharpProject(const std::string& csprojPath, const std::string&
 		std::string logContent = buffer.str();
 		
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog("C# Build Failed. Log output:", LogLevel::Error);
-		DebugLog(logContent, LogLevel::Error);
+		QFE_LOG("C# Build Failed. Log output:", LogLevel::Error);
+		QFE_LOG(logContent, LogLevel::Error);
 #else
 		std::cerr << "C# Build Failed:\n" << logContent << std::endl;
 #endif

--- a/project/engine/src/assets/Script/CsharpScriptExecutor.cpp
+++ b/project/engine/src/assets/Script/CsharpScriptExecutor.cpp
@@ -22,7 +22,7 @@ void CsharpScriptExecutor::Initialize(EntityManager* entityManager) {
 	// MonoRuntimeManagerが初期化されているか確認
 	if (!MonoRuntimeManager::GetInstance()->IsInitialized()) {
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog("MonoRuntimeManager is not initialized.", LogLevel::Error);
+		QFE_LOG("MonoRuntimeManager is not initialized.", LogLevel::Error);
 #endif
 		return;
 	}
@@ -38,7 +38,7 @@ void CsharpScriptExecutor::Initialize(EntityManager* entityManager) {
 
 	if (!domain_) {
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog("Failed to create AppDomain for scene.", LogLevel::Error);
+		QFE_LOG("Failed to create AppDomain for scene.", LogLevel::Error);
 #endif
 		return;
 	}
@@ -46,13 +46,13 @@ void CsharpScriptExecutor::Initialize(EntityManager* entityManager) {
 	// ドメインを切り替え
 	if (!mono_domain_set(domain_, false)) {
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog("Failed to set AppDomain.", LogLevel::Error);
+		QFE_LOG("Failed to set AppDomain.", LogLevel::Error);
 #endif
 		return;
 	}
 
 #ifdef QFE_OPTIMIZE_OFF
-	DebugLog("CsharpScriptExecutor initialized with new AppDomain.");
+	QFE_LOG("CsharpScriptExecutor initialized with new AppDomain.");
 #endif
 
 	// アセンブリをロード
@@ -62,7 +62,7 @@ void CsharpScriptExecutor::Initialize(EntityManager* entityManager) {
 void CsharpScriptExecutor::LoadAssembly() {
 	if (!domain_) {
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog("Domain not initialized. Cannot load assembly.", LogLevel::Error);
+		QFE_LOG("Domain not initialized. Cannot load assembly.", LogLevel::Error);
 #endif
 		return;
 	}
@@ -72,11 +72,11 @@ void CsharpScriptExecutor::LoadAssembly() {
 
 	if (!assembly_) {
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog("Failed to load assembly: " + assemblyPath, LogLevel::Error);
+		QFE_LOG("Failed to load assembly: " + assemblyPath, LogLevel::Error);
 #endif
 	} else {
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog("Assembly loaded successfully: " + assemblyPath);
+		QFE_LOG("Assembly loaded successfully: " + assemblyPath);
 #endif
 	}
 }
@@ -86,7 +86,7 @@ std::vector<std::string> CsharpScriptExecutor::GetAvailableScriptClasses() const
 
 	if (!assembly_) {
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog("Error: Assembly is not loaded. Cannot get script class names.", LogLevel::Error);
+		QFE_LOG("Error: Assembly is not loaded. Cannot get script class names.", LogLevel::Error);
 #endif
 		return classNames;
 	}
@@ -95,7 +95,7 @@ std::vector<std::string> CsharpScriptExecutor::GetAvailableScriptClasses() const
 
 	if (!image) {
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog("Error: Could not get image from assembly.", LogLevel::Error);
+		QFE_LOG("Error: Could not get image from assembly.", LogLevel::Error);
 #endif
 		return classNames;
 	}
@@ -104,7 +104,7 @@ std::vector<std::string> CsharpScriptExecutor::GetAvailableScriptClasses() const
 
 	if (!type_definitions_table) {
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog("Error: Could not get type definitions table from image.", LogLevel::Error);
+		QFE_LOG("Error: Could not get type definitions table from image.", LogLevel::Error);
 #endif
 		return classNames;
 	}
@@ -112,7 +112,7 @@ std::vector<std::string> CsharpScriptExecutor::GetAvailableScriptClasses() const
 	int num_types = mono_table_info_get_rows(type_definitions_table);
 
 #ifdef QFE_OPTIMIZE_OFF
-	DebugLog(std::format("Scanning assembly for classes... Found {} type definitions.", num_types));
+	QFE_LOG(std::format("Scanning assembly for classes... Found {} type definitions.", num_types));
 #endif
 
 	for (int i = 0; i < num_types; i++) {
@@ -140,18 +140,18 @@ std::vector<std::string> CsharpScriptExecutor::GetAvailableScriptClasses() const
 
 		if (full_name.find("QuickForgeEngine") != std::string::npos) {
 #ifdef QFE_OPTIMIZE_OFF
-			DebugLog(std::format("Found QuickForgeEngine class: {}", full_name));
+			QFE_LOG(std::format("Found QuickForgeEngine class: {}", full_name));
 #endif
 			continue;
 		}
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog(std::format("Found valid class: {}", full_name));
+		QFE_LOG(std::format("Found valid class: {}", full_name));
 #endif
 		classNames.push_back(full_name);
 	}
 
 #ifdef QFE_OPTIMIZE_OFF
-	DebugLog(std::format("Finished scanning. Returning {} valid classes.", classNames.size()));
+	QFE_LOG(std::format("Finished scanning. Returning {} valid classes.", classNames.size()));
 #endif
 	return classNames;
 }
@@ -159,7 +159,7 @@ std::vector<std::string> CsharpScriptExecutor::GetAvailableScriptClasses() const
 uint32_t CsharpScriptExecutor::CreateScriptInstance(uint32_t entityId, const std::string& className) {
 	if (!assembly_) {
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog("Assembly not loaded. Cannot create script instance.", LogLevel::Error);
+		QFE_LOG("Assembly not loaded. Cannot create script instance.", LogLevel::Error);
 #endif
 		return 0;
 	}
@@ -178,7 +178,7 @@ uint32_t CsharpScriptExecutor::CreateScriptInstance(uint32_t entityId, const std
 	MonoClass* monoClass = mono_class_from_name(image, ns_name.c_str(), class_name.c_str());
 	if (!monoClass) {
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog("Class not found: " + className, LogLevel::Error);
+		QFE_LOG("Class not found: " + className, LogLevel::Error);
 #endif
 		return 0;
 	}
@@ -199,7 +199,7 @@ uint32_t CsharpScriptExecutor::CreateScriptInstance(uint32_t entityId, const std
 			if (exceptionMsg) {
 				char* exceptionCStr = mono_string_to_utf8(exceptionMsg);
 #ifdef QFE_OPTIMIZE_OFF
-				DebugLog(std::string("Mono Exception: ") + exceptionCStr, LogLevel::Error);
+				QFE_LOG(std::string("Mono Exception: ") + exceptionCStr, LogLevel::Error);
 #endif
 				mono_free(exceptionCStr);
 			}
@@ -209,7 +209,7 @@ uint32_t CsharpScriptExecutor::CreateScriptInstance(uint32_t entityId, const std
 	scripts_.push_back(instance);
 
 #ifdef QFE_OPTIMIZE_OFF
-	DebugLog(std::format("Created C# script instance: {} (index: {})", className, scripts_.size() - 1));
+	QFE_LOG(std::format("Created C# script instance: {} (index: {})", className, scripts_.size() - 1));
 #endif
 
 	return static_cast<uint32_t>(scripts_.size()) - 1;
@@ -218,7 +218,7 @@ uint32_t CsharpScriptExecutor::CreateScriptInstance(uint32_t entityId, const std
 void QFE::CsharpScriptExecutor::CreateScriptInstance(const std::string& className) {
 	if (!assembly_) {
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog("Assembly not loaded. Cannot create script instance.");
+		QFE_LOG("Assembly not loaded. Cannot create script instance.");
 #endif // QFE_OPTIMIZE_OFF
 		return;
 	}
@@ -235,7 +235,7 @@ void QFE::CsharpScriptExecutor::CreateScriptInstance(const std::string& classNam
 	MonoClass* monoClass = mono_class_from_name(image, ns_name.c_str(), class_name.c_str());
 	if (!monoClass) {
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog("Class not found: " + className);
+		QFE_LOG("Class not found: " + className);
 #endif // QFE_OPTIMIZE_OFF
 		return;
 	}
@@ -244,7 +244,7 @@ void QFE::CsharpScriptExecutor::CreateScriptInstance(const std::string& classNam
 	scripts_.push_back(instance);
 
 #ifdef QFE_OPTIMIZE_OFF
-	DebugLog(std::format("Create Instance index: {}", static_cast<uint32_t>(scripts_.size()) - 1));
+	QFE_LOG(std::format("Create Instance index: {}", static_cast<uint32_t>(scripts_.size()) - 1));
 #endif // QFE_OPTIMIZE_OFF
 	return;
 }
@@ -252,20 +252,20 @@ void QFE::CsharpScriptExecutor::CreateScriptInstance(const std::string& classNam
 void CsharpScriptExecutor::DeleteScriptInstance(uint32_t index) {
 	if (index >= scripts_.size()) {
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog("Invalid script index: " + std::to_string(index), LogLevel::Error);
+		QFE_LOG("Invalid script index: " + std::to_string(index), LogLevel::Error);
 #endif
 		return;
 	}
 	scripts_.erase(static_cast<size_t>(index));
 #ifdef QFE_OPTIMIZE_OFF
-	DebugLog("Deleted script instance at index: " + std::to_string(index));
+	QFE_LOG("Deleted script instance at index: " + std::to_string(index));
 #endif
 }
 
 void CsharpScriptExecutor::RunScriptFunction(uint32_t index, const std::string& functionName) {
 	if (index >= scripts_.size()) {
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog("Invalid script index: " + std::to_string(index), LogLevel::Error);
+		QFE_LOG("Invalid script index: " + std::to_string(index), LogLevel::Error);
 #endif
 		return;
 	}
@@ -276,7 +276,7 @@ void CsharpScriptExecutor::RunScriptFunction(uint32_t index, const std::string& 
 
 	if (!method) {
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog("Method not found: " + functionName, LogLevel::Warning);
+		QFE_LOG("Method not found: " + functionName, LogLevel::Warning);
 #endif
 		return;
 	}
@@ -289,7 +289,7 @@ void CsharpScriptExecutor::RunScriptFunction(uint32_t index, const std::string& 
 		if (exceptionMsg) {
 			char* exceptionCStr = mono_string_to_utf8(exceptionMsg);
 #ifdef QFE_OPTIMIZE_OFF
-			DebugLog("C# Script[" + std::to_string(index) + "]: " + exceptionCStr, LogLevel::Error);
+			QFE_LOG("C# Script[" + std::to_string(index) + "]: " + exceptionCStr, LogLevel::Error);
 #endif
 			mono_free(exceptionCStr);
 		}
@@ -305,7 +305,7 @@ void CsharpScriptExecutor::RunAllScriptsFunction(const std::string& functionName
 void CsharpScriptExecutor::ResetScripts() {
 	scripts_.clear();
 #ifdef QFE_OPTIMIZE_OFF
-	DebugLog("All C# scripts reset.");
+	QFE_LOG("All C# scripts reset.");
 #endif
 }
 
@@ -329,14 +329,14 @@ void CsharpScriptExecutor::ReloadAssembly() {
 	domain_ = mono_domain_create_appdomain(domainName, nullptr);
 	if (!domain_) {
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog("Failed to create new app domain.", LogLevel::Error);
+		QFE_LOG("Failed to create new app domain.", LogLevel::Error);
 #endif
 		return;
 	}
 
 	if (!mono_domain_set(domain_, false)) {
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog("Failed to set app domain.", LogLevel::Error);
+		QFE_LOG("Failed to set app domain.", LogLevel::Error);
 #endif
 		return;
 	}
@@ -345,7 +345,7 @@ void CsharpScriptExecutor::ReloadAssembly() {
 	LoadAssembly();
 
 #ifdef QFE_OPTIMIZE_OFF
-	DebugLog("C# assembly reloaded.");
+	QFE_LOG("C# assembly reloaded.");
 #endif
 }
 
@@ -365,6 +365,6 @@ void CsharpScriptExecutor::Finalize() {
 	}
 
 #ifdef QFE_OPTIMIZE_OFF
-	DebugLog("CsharpScriptExecutor finalized.");
+	QFE_LOG("CsharpScriptExecutor finalized.");
 #endif
 }

--- a/project/engine/src/assets/Script/MonoRuntimeManager.cpp
+++ b/project/engine/src/assets/Script/MonoRuntimeManager.cpp
@@ -19,14 +19,14 @@ void MonoRuntimeManager::Initialize() {
 	GetModuleFileNameW(NULL, path, MAX_PATH);
 
 #ifdef QFE_OPTIMIZE_OFF
-	DebugLog("Initializing Mono JIT...");
+	QFE_LOG("Initializing Mono JIT...");
 #endif
 
 	std::filesystem::path exeDir(path);
 	exeDir = exeDir.parent_path();
 
 #ifdef QFE_OPTIMIZE_OFF
-	DebugLog("Executable Directory: " + exeDir.string());
+	QFE_LOG("Executable Directory: " + exeDir.string());
 #endif
 
 	// Monoディレクトリの設定
@@ -38,8 +38,8 @@ void MonoRuntimeManager::Initialize() {
 	std::string monoEtcPathUtf8 = ConvertString(monoEtcPath.wstring());
 
 #ifdef QFE_OPTIMIZE_OFF
-	DebugLog("Mono Lib Path: " + monoLibPath.string());
-	DebugLog("Mono Etc Path: " + monoEtcPath.string());
+	QFE_LOG("Mono Lib Path: " + monoLibPath.string());
+	QFE_LOG("Mono Etc Path: " + monoEtcPath.string());
 #endif
 
 	try {
@@ -48,7 +48,7 @@ void MonoRuntimeManager::Initialize() {
 	catch (const std::exception& e) {
 		e;
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog(std::string("Failed to set Mono directories: ") + e.what());
+		QFE_LOG(std::string("Failed to set Mono directories: ") + e.what());
 #endif
 		return;
 	}
@@ -59,7 +59,7 @@ void MonoRuntimeManager::Initialize() {
 		"--debugger-agent=transport=dt_socket,server=y,address=0.0.0.0:55555,suspend=n"
 	};
 	mono_jit_parse_options(sizeof(options) / sizeof(char*), (char**)options);
-	DebugLog("Mono JIT options set for debugging.");
+	QFE_LOG("Mono JIT options set for debugging.");
 #endif
 
 	// JIT初期化（プロセスごとに1回のみ）
@@ -69,20 +69,20 @@ void MonoRuntimeManager::Initialize() {
 	catch (const std::exception& e) {
 		e;
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog(std::string("Failed to initialize Mono JIT: ") + e.what());
+		QFE_LOG(std::string("Failed to initialize Mono JIT: ") + e.what());
 #endif
 		return;
 	}
 
 	if (!rootDomain_) {
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog("Failed to initialize Mono JIT.");
+		QFE_LOG("Failed to initialize Mono JIT.");
 #endif
 		return;
 	}
 
 #ifdef QFE_OPTIMIZE_OFF
-	DebugLog("Success to initialize Mono JIT.");
+	QFE_LOG("Success to initialize Mono JIT.");
 #endif
 
 #ifdef QFE_OPTIMIZE_OFF
@@ -164,7 +164,7 @@ void MonoRuntimeManager::RegisterQFEAPI() {
 		(const void*)CsharpOnQFELinker::Rotate);
 
 #ifdef QFE_OPTIMIZE_OFF
-	DebugLog("QFE C# API registered successfully.");
+	QFE_LOG("QFE C# API registered successfully.");
 #endif
 }
 
@@ -190,13 +190,13 @@ void MonoRuntimeManager::CompileScripts() {
 	try {
 		QFE::CompileCSharpProject(csprojPath, dllPath);
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog("C# scripts compiled successfully.");
+		QFE_LOG("C# scripts compiled successfully.");
 #endif
 	}
 	catch (const std::exception& e) {
 		e;
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog(std::string("Failed to compile C# scripts: ") + e.what(), LogLevel::Error);
+		QFE_LOG(std::string("Failed to compile C# scripts: ") + e.what(), LogLevel::Error);
 #endif
 	}
 }
@@ -225,7 +225,7 @@ void MonoRuntimeManager::Finalize() {
 	// Monoランタイム全体をクリーンアップ
 	if (rootDomain_) {
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog("Cleaning up Mono JIT...");
+		QFE_LOG("Cleaning up Mono JIT...");
 #endif
 		mono_jit_cleanup(rootDomain_);
 		rootDomain_ = nullptr;

--- a/project/engine/src/audio/Core/XAudioCore.cpp
+++ b/project/engine/src/audio/Core/XAudioCore.cpp
@@ -45,7 +45,7 @@ void XAudioCore::Initialize() {
 	assert(SUCCEEDED(hr));
 
 #ifdef QFE_OPTIMIZE_OFF
-	DebugLog(ConvertString(std::format(L"MasterVoice->nChannels:{}", GetOutputChannels())));
+	QFE_LOG(ConvertString(std::format(L"MasterVoice->nChannels:{}", GetOutputChannels())));
 
 	// 髻ｳ螢ｰ繝・ヰ繧､繧ｹ繧定｡ｨ遉ｺ
 	IMMDeviceEnumerator* pEnumerator = NULL;
@@ -65,10 +65,10 @@ void XAudioCore::Initialize() {
 
 	if (count == 0)
 	{
-		DebugLog("No active rendering audio endpoints found.");
+		QFE_LOG("No active rendering audio endpoints found.");
 	} else
 	{
-		DebugLog("Active Rendering Audio Endpoints");
+		QFE_LOG("Active Rendering Audio Endpoints");
 		for (UINT i = 0; i < count; i++)
 		{
 			// 繧ｳ繝ｬ繧ｯ繧ｷ繝ｧ繝ｳ縺九ｉ蛟句挨縺ｮ繧ｨ繝ｳ繝峨・繧､繝ｳ繝医ｒ蜿門ｾ・
@@ -91,10 +91,10 @@ void XAudioCore::Initialize() {
 			// 蜿門ｾ励＠縺溘・繝ｭ繝代ユ繧｣蛟､繧定｡ｨ遉ｺ
 			if (varName.vt == VT_LPWSTR) // 蛟､縺ｮ蝙九′繝ｯ繧､繝画枚蟄怜・縺狗｢ｺ隱・
 			{
-				DebugLog("ActiveAudioDeviceName: " + ConvertString(varName.pwszVal));
+				QFE_LOG("ActiveAudioDeviceName: " + ConvertString(varName.pwszVal));
 			} else
 			{
-				DebugLog("ActiveAudioDeviceName = Unknown format");
+				QFE_LOG("ActiveAudioDeviceName = Unknown format");
 			}
 
 			// PROPVARIANT 縺ｮ隗｣謾ｾ

--- a/project/engine/src/audio/Player/AudioChipManager.cpp
+++ b/project/engine/src/audio/Player/AudioChipManager.cpp
@@ -37,7 +37,7 @@ void AudioChipManager::StopSound(uint32_t soundHandle) {
 	catch (const std::exception& e) {
 		e;
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog(std::string("StopSound error: ") + e.what());
+		QFE_LOG(std::string("StopSound error: ") + e.what());
 #endif // QFE_OPTIMIZE_OFF
 	}
 }
@@ -51,7 +51,7 @@ void AudioChipManager::PauseSound(uint32_t soundHandle) {
 	catch (const std::exception& e) {
 		e;
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog(std::string("PauseSound error: ") + e.what());
+		QFE_LOG(std::string("PauseSound error: ") + e.what());
 #endif // QFE_OPTIMIZE_OFF
 	}
 }
@@ -65,7 +65,7 @@ void AudioChipManager::ResumeSound(uint32_t soundHandle) {
 	catch (const std::exception& e) {
 		e;
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog(std::string("ResumeSound error: ") + e.what());
+		QFE_LOG(std::string("ResumeSound error: ") + e.what());
 #endif // QFE_OPTIMIZE_OFF
 	}
 }
@@ -99,7 +99,7 @@ void AudioChipManager::SetVolume(uint32_t soundHandle, float volume) {
 	catch (const std::exception& e) {
 		e;
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog(std::string("SetVolume error: ") + e.what());
+		QFE_LOG(std::string("SetVolume error: ") + e.what());
 #endif // QFE_OPTIMIZE_OFF
 	}
 }
@@ -113,7 +113,7 @@ float AudioChipManager::GetVolume(uint32_t soundHandle) const {
 	catch (const std::exception& e) {
 		e;
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog(std::string("GetVolume error: ") + e.what());
+		QFE_LOG(std::string("GetVolume error: ") + e.what());
 #endif // QFE_OPTIMIZE_OFF
 	}
 	return 0.0f;

--- a/project/engine/src/collider/ColliderManager.cpp
+++ b/project/engine/src/collider/ColliderManager.cpp
@@ -137,7 +137,7 @@ namespace QFE {
 					// 繧ｿ繧ｰ繝槭せ繧ｯ縺瑚｡晉ｪ∝庄閭ｽ縺・
 					if (colliderTagMask_.IsCollidable(objA->tag, objB->tag)) {
 #ifdef QFE_OPTIMIZE_OFF
-						DebugLog(std::format("Collider Tag Mismatch between Entity {} and Entity {}", idA, idB));
+						QFE_LOG(std::format("Collider Tag Mismatch between Entity {} and Entity {}", idA, idB));
 #endif // QFE_OPTIMIZE_OFF
 						continue;
 					}
@@ -145,7 +145,7 @@ namespace QFE {
 					// 陦晉ｪ√う繝吶Φ繝医ｒ逋ｺ逕溘＆縺帙ｋ繝ｬ繧､繝､繝ｼ縺・
 					if ((colliderA.eventColliderLayer & colliderB.colliderLayer) == 0) {
 #ifdef QFE_OPTIMIZE_OFF
-						DebugLog(std::format("Collider Event Layer Mismatch between Entity {} and Entity {}", idA, idB));
+						QFE_LOG(std::format("Collider Event Layer Mismatch between Entity {} and Entity {}", idA, idB));
 #endif // QFE_OPTIMIZE_OFF
 						continue;
 					}
@@ -157,7 +157,7 @@ namespace QFE {
 					// 蜿咲匱縺励≧繧九Ξ繧､繝､繝ｼ縺・
 					if ((colliderA.colliderLayer & colliderB.eventColliderLayer) == 0) {
 #ifdef QFE_OPTIMIZE_OFF
-						DebugLog(std::format("Collider Repulsion Layer Mismatch between Entity{} and Entity {}", idA, idB));
+						QFE_LOG(std::format("Collider Repulsion Layer Mismatch between Entity{} and Entity {}", idA, idB));
 #endif // QFE_OPTIMIZE_OFF
 						continue;
 					}
@@ -233,7 +233,7 @@ namespace QFE {
 					// 繧ｿ繧ｰ繝槭せ繧ｯ縺瑚｡晉ｪ∝庄閭ｽ縺・
 					if (colliderTagMask_.IsCollidable(objA->tag, objB->tag)) {
 #ifdef QFE_OPTIMIZE_OFF
-						DebugLog(std::format("Collider Tag Mismatch between Entity {} and Entity {}", idA, idB));
+						QFE_LOG(std::format("Collider Tag Mismatch between Entity {} and Entity {}", idA, idB));
 #endif // QFE_OPTIMIZE_OFF
 						continue;
 					}
@@ -241,7 +241,7 @@ namespace QFE {
 					// 陦晉ｪ√う繝吶Φ繝医ｒ逋ｺ逕溘＆縺帙ｋ繝ｬ繧､繝､繝ｼ縺・
 					if ((colliderA.eventColliderLayer & colliderB.colliderLayer) == 0) {
 #ifdef QFE_OPTIMIZE_OFF
-						DebugLog(std::format("Collider Event Layer Mismatch between Entity {} and Entity {}", idA, idB));
+						QFE_LOG(std::format("Collider Event Layer Mismatch between Entity {} and Entity {}", idA, idB));
 #endif // QFE_OPTIMIZE_OFF
 						continue;
 					}
@@ -253,7 +253,7 @@ namespace QFE {
 					// 蜿咲匱縺励≧繧九Ξ繧､繝､繝ｼ縺・
 					if ((colliderA.colliderLayer & colliderB.eventColliderLayer) == 0) {
 #ifdef QFE_OPTIMIZE_OFF
-						DebugLog(std::format("Collider Repulsion Layer Mismatch between Entity{} and Entity {}", idA, idB));
+						QFE_LOG(std::format("Collider Repulsion Layer Mismatch between Entity{} and Entity {}", idA, idB));
 #endif // QFE_OPTIMIZE_OFF
 						continue;
 					}
@@ -374,7 +374,7 @@ namespace QFE {
 					// 繧ｿ繧ｰ繝槭せ繧ｯ縺瑚｡晉ｪ∝庄閭ｽ縺・
 					if (colliderTagMask_.IsCollidable(objA->tag, objB->tag)) {
 #ifdef QFE_OPTIMIZE_OFF
-						DebugLog(std::format("Collider Tag Mismatch between Entity {} and Entity {}", sphereId, aabbId));
+						QFE_LOG(std::format("Collider Tag Mismatch between Entity {} and Entity {}", sphereId, aabbId));
 #endif // QFE_OPTIMIZE_OFF
 						continue;
 					}
@@ -382,7 +382,7 @@ namespace QFE {
 					// 陦晉ｪ√う繝吶Φ繝医ｒ逋ｺ逕溘＆縺帙ｋ繝ｬ繧､繝､繝ｼ縺・
 					if ((sphereCollider.eventColliderLayer & aabbCollider.colliderLayer) == 0) {
 #ifdef QFE_OPTIMIZE_OFF
-						DebugLog(std::format("Collider Event Layer Mismatch between Entity {} and Entity {}", sphereId, aabbId));
+						QFE_LOG(std::format("Collider Event Layer Mismatch between Entity {} and Entity {}", sphereId, aabbId));
 #endif // QFE_OPTIMIZE_OFF
 						continue;
 					}
@@ -394,7 +394,7 @@ namespace QFE {
 					// 蜿咲匱縺励≧繧九Ξ繧､繝､繝ｼ縺・
 					if ((sphereCollider.colliderLayer & aabbCollider.eventColliderLayer) == 0) {
 #ifdef QFE_OPTIMIZE_OFF
-						DebugLog(std::format("Collider Repulsion Layer Mismatch between Entity{} and Entity {}", sphereId, aabbId));
+						QFE_LOG(std::format("Collider Repulsion Layer Mismatch between Entity{} and Entity {}", sphereId, aabbId));
 #endif // QFE_OPTIMIZE_OFF
 						continue;
 					}

--- a/project/engine/src/collider/ColliderMask.cpp
+++ b/project/engine/src/collider/ColliderMask.cpp
@@ -37,7 +37,7 @@ void ColliderTagMask::Initialize(const std::string& maskTableFilePath)
 	{
 		e;
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog(e.what());
+		QFE_LOG(e.what());
 #endif // QFE_OPTIMIZE_OFF
 		// 読み込み失敗時は空のテーブルで初期化
 		tagMaskPairs_.clear();
@@ -63,7 +63,7 @@ void ColliderTagMask::Finalize()
 	catch (const std::exception& e) {
 		e;
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog(e.what());
+		QFE_LOG(e.what());
 #endif // QFE_OPTIMIZE_OFF
 	}
 }
@@ -84,7 +84,7 @@ void ColliderTagMask::EraseTagMaskPair(const std::string& tag1, const std::strin
         tagMaskPairs_.erase(indexToErase);
 	} else {
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog("Tag mask pair not found: (" + tag1 + ", " + tag2 + ")", LogLevel::Error);
+		QFE_LOG("Tag mask pair not found: (" + tag1 + ", " + tag2 + ")", LogLevel::Error);
 #endif // QFE_OPTIMIZE_OFF
 	}
 }

--- a/project/engine/src/core/Bridge/EditorEngineBridgeRegistry.cpp
+++ b/project/engine/src/core/Bridge/EditorEngineBridgeRegistry.cpp
@@ -445,7 +445,7 @@ void QFE::EditorEngineBridgeRegistry::RegisterFunctions(WindowsEngineCore* engin
 		};
 	EditorEngineBridge::AddCameraEntity = [engineCore]() {
 		// カメラの機能がシングルトンであるため、複数カメラにすると不具合が起きる可能性があるため一時的に制限
-		DebugLog("Can not add Camera.");
+		QFE_LOG("Can not add Camera.");
 		};
 	EditorEngineBridge::CopyEntity = [engineCore](uint32_t entityId) {
 		SceneManager* sceneManager_ = engineCore->GetSceneManager();
@@ -480,7 +480,7 @@ void QFE::EditorEngineBridgeRegistry::RegisterFunctions(WindowsEngineCore* engin
 
 	EditorEngineBridge::GetDebugCameraEntityId = [engineCore]() -> uint32_t {
 		if (!CameraManager::GetInstance()) {
-			DebugLog("CameraManager is not initialized.");
+			QFE_LOG("CameraManager is not initialized.");
 			return UINT32_MAX;
 		}
 		return CameraManager::GetInstance()->GetCamera(0).GetBindEntityId();

--- a/project/engine/src/core/Thread/ThreadPool.cpp
+++ b/project/engine/src/core/Thread/ThreadPool.cpp
@@ -6,7 +6,7 @@
 QFE::ThreadPool::ThreadPool() {
 	size_t threadCount = std::thread::hardware_concurrency();
 #ifdef QFE_OPTIMIZE_OFF
-	DebugLog("Hardware Concurrency: " + std::to_string(threadCount));
+	QFE_LOG("Hardware Concurrency: " + std::to_string(threadCount));
 #endif // QFE_OPTIMIZE_OFF
 
 	if (threadCount > 1) {

--- a/project/engine/src/graphic/DirectXCommon/Descriptors/DescriptorGenerator.cpp
+++ b/project/engine/src/graphic/DirectXCommon/Descriptors/DescriptorGenerator.cpp
@@ -7,8 +7,8 @@ using namespace QFE;
 void DescriptorGenerator::GenerateDescriptorHeap(Microsoft::WRL::ComPtr<ID3D12DescriptorHeap>& heap, ID3D12Device* device, const DescriptorGenerateConfig& config) {
 	assert(!heap && "Already generated");
 #ifdef QFE_OPTIMIZE_OFF
-	DebugLog("CreateDescriptorHeap");
-	DebugLog(std::format("NumDescriptors: {}, ShaderVisible: {}",
+	QFE_LOG("CreateDescriptorHeap");
+	QFE_LOG(std::format("NumDescriptors: {}, ShaderVisible: {}",
 		config.numDescriptors, config.shaderVisible ? "true" : "false"));
 #endif // QFE_OPTIMIZE_OFF
 

--- a/project/engine/src/graphic/DirectXCommon/Descriptors/DescriptorHeapManager.cpp
+++ b/project/engine/src/graphic/DirectXCommon/Descriptors/DescriptorHeapManager.cpp
@@ -6,7 +6,7 @@
 using namespace QFE;
 void DescriptorHeapManager::Initialize(ID3D12Device* device) {
 #ifdef QFE_OPTIMIZE_OFF
-	DebugLog("-----DescriptorHeapManager:Initialize-----\n");
+	QFE_LOG("-----DescriptorHeapManager:Initialize-----\n");
 #endif // QFE_OPTIMIZE_OFF
 	rtvDescriptorHeap.Initialize(device, kMaxRtvDescriptors, false);
 	srvDescriptorHeap.Initialize(device, kMaxSrvDescriptors, true);

--- a/project/engine/src/graphic/DirectXCommon/Descriptors/DsvDescriptorHeap.cpp
+++ b/project/engine/src/graphic/DirectXCommon/Descriptors/DsvDescriptorHeap.cpp
@@ -39,7 +39,7 @@ DescriptorHandles DsvDescriptorHeap::AssignHeap(ID3D12Resource* resource, const 
 	assert(!freeDescriptors_.empty() && "No free descriptors available.");
 	UINT index = freeDescriptors_.front();
 #ifdef QFE_OPTIMIZE_OFF
-	DebugLog(std::format("AssignHeapIndex: {}", index));
+	QFE_LOG(std::format("AssignHeapIndex: {}", index));
 #endif // QFE_OPTIMIZE_OFF
 	freeDescriptors_.pop();
 	// ディスクリプタハンドルを取得

--- a/project/engine/src/graphic/DirectXCommon/Descriptors/RtvDescriptorHeap.cpp
+++ b/project/engine/src/graphic/DirectXCommon/Descriptors/RtvDescriptorHeap.cpp
@@ -9,7 +9,7 @@
 using namespace QFE;
 void RtvDescriptorHeap::Initialize(ID3D12Device* device, UINT numDescriptors, bool shaderVisible) {
 #ifdef QFE_OPTIMIZE_OFF
-	DebugLog("-----RtvDescriptorHeap:Initialize-----");
+	QFE_LOG("-----RtvDescriptorHeap:Initialize-----");
 #endif // QFE_OPTIMIZE_OFF
 	// 繝・ぅ繧ｹ繧ｯ繝ｪ繝励ち逕滓・險ｭ螳壹・蛻晄悄蛹・
 	descriptorGenerateConfig_.descriptorSize = device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
@@ -43,7 +43,7 @@ DescriptorHandles RtvDescriptorHeap::AssignHeap(ID3D12Resource* resource,const D
 	assert(!freeDescriptors_.empty() && "No free descriptors available.");
 	UINT index = freeDescriptors_.front();
 #ifdef QFE_OPTIMIZE_OFF
-	DebugLog(std::format("AssignHeapIndex: {}", index));
+	QFE_LOG(std::format("AssignHeapIndex: {}", index));
 #endif // QFE_OPTIMIZE_OFF
 	freeDescriptors_.pop();
 	// 繝・ぅ繧ｹ繧ｯ繝ｪ繝励ち繝上Φ繝峨Ν繧貞叙蠕・

--- a/project/engine/src/graphic/DirectXCommon/Descriptors/SrvDescriptorHeap.cpp
+++ b/project/engine/src/graphic/DirectXCommon/Descriptors/SrvDescriptorHeap.cpp
@@ -10,7 +10,7 @@
 using namespace QFE;
 void SrvDescriptorHeap::Initialize(ID3D12Device* device, UINT numDescriptors, bool shaderVisible) {
 #ifdef QFE_OPTIMIZE_OFF
-	DebugLog("-----SrvDescriptorHeap:Initialize-----");
+	QFE_LOG("-----SrvDescriptorHeap:Initialize-----");
 #endif // QFE_OPTIMIZE_OFF
 	// 繝・ぅ繧ｹ繧ｯ繝ｪ繝励ち逕滓・險ｭ螳壹・蛻晄悄蛹・
 	descriptorGenerateConfig_.descriptorSize = device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
@@ -44,7 +44,7 @@ DescriptorHandles SrvDescriptorHeap::AssignHeap(ID3D12Resource* resource, const 
 	assert(!freeDescriptors_.empty() && "No free descriptors available.");
 	UINT index = freeDescriptors_.front();
 #ifdef QFE_OPTIMIZE_OFF
-	DebugLog(std::format("Srv_AssignHeapIndex: {}", index));
+	QFE_LOG(std::format("Srv_AssignHeapIndex: {}", index));
 #endif // QFE_OPTIMIZE_OFF
 	freeDescriptors_.pop();
 	// 繝・ぅ繧ｹ繧ｯ繝ｪ繝励ち繝上Φ繝峨Ν繧貞叙蠕・

--- a/project/engine/src/graphic/DirectXCommon/DirectXCommandManager.cpp
+++ b/project/engine/src/graphic/DirectXCommon/DirectXCommandManager.cpp
@@ -7,7 +7,7 @@
 using namespace QFE;
 void DirectXCommandManager::Initialize(ID3D12Device* device) {
 #ifdef QFE_OPTIMIZE_OFF
-	DebugLog("Initialize called.");
+	QFE_LOG("Initialize called.");
 #endif // QFE_OPTIMIZE_OFF
 
 	assert(device && "Device is not initialized.");

--- a/project/engine/src/graphic/DirectXCommon/SwapChain.cpp
+++ b/project/engine/src/graphic/DirectXCommon/SwapChain.cpp
@@ -32,7 +32,7 @@ namespace QFE {
 			hr = swapChain_.Get()->GetBuffer(i, IID_PPV_ARGS(backBuffers_.at(i).GetAddressOf()));
 			assert(SUCCEEDED(hr));
 #ifdef QFE_OPTIMIZE_OFF
-			DebugLog(std::format("Assign BackBuffer: {}", i));
+			QFE_LOG(std::format("Assign BackBuffer: {}", i));
 #endif // QFE_OPTIMIZE_OFF
 		}
 	}
@@ -80,7 +80,7 @@ namespace QFE {
 
 	void SwapChain::AssignDescriptorHandles(const DescriptorHandles& rtvHandle, uint32_t index) {
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog(std::format("Add DescriptorHandles to SwapChain: {}", index));
+		QFE_LOG(std::format("Add DescriptorHandles to SwapChain: {}", index));
 #endif // QFE_OPTIMIZE_OFF
 		assert(index < backBuffers_.size() && "Index out of range in AssignDescriptorHandles.");
 		backBufferViews_[index] = rtvHandle;
@@ -88,7 +88,7 @@ namespace QFE {
 
 	bool SwapChain::CheckBackBufferViews() const {
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog(std::format("Buffer: {} View: {}", backBuffers_.size(), backBufferViews_.size()));
+		QFE_LOG(std::format("Buffer: {} View: {}", backBuffers_.size(), backBufferViews_.size()));
 #endif // QFE_OPTIMIZE_OFF
 		// バックバッファがnullptrではないか確認
 		for (const auto& buffer : backBuffers_) {

--- a/project/engine/src/graphic/DirectXDevice.cpp
+++ b/project/engine/src/graphic/DirectXDevice.cpp
@@ -22,17 +22,17 @@ namespace QFE {
 
 	DirectXDevice::~DirectXDevice() {
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog("-----DirectXDevice:Shutdown-----\n");
-		DebugLog(std::format("Disable Error : {}\n", disableError_ ? "true" : "false"));
-		DebugLog(std::format("Disable Warning : {}\n", disableWarning_ ? "true" : "false"));
+		QFE_LOG("-----DirectXDevice:Shutdown-----\n");
+		QFE_LOG(std::format("Disable Error : {}\n", disableError_ ? "true" : "false"));
+		QFE_LOG(std::format("Disable Warning : {}\n", disableWarning_ ? "true" : "false"));
 #endif // QFE_OPTIMIZE_OFF
 	}
 
 	void DirectXDevice::Initialize() {
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog("-----DirectXDevice:Initialize-----\n");
-		DebugLog(std::format("Disable Error : {}\n", disableError_ ? "true" : "false"));
-		DebugLog(std::format("Disable Warning : {}\n", disableWarning_ ? "true" : "false"));
+		QFE_LOG("-----DirectXDevice:Initialize-----\n");
+		QFE_LOG(std::format("Disable Error : {}\n", disableError_ ? "true" : "false"));
+		QFE_LOG(std::format("Disable Warning : {}\n", disableWarning_ ? "true" : "false"));
 #endif // QFE_OPTIMIZE_OFF
 		// DXGIファクトリーの生成
 		CreateDxgiFactory();
@@ -41,7 +41,7 @@ namespace QFE {
 		// D3D12Deviceの生成
 		CreateDevice();
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog("-----DirectXDevice:Initialize Complete-----\n");
+		QFE_LOG("-----DirectXDevice:Initialize Complete-----\n");
 #endif // QFE_OPTIMIZE_OFF
 	}
 
@@ -62,11 +62,11 @@ namespace QFE {
 #ifdef QFE_OPTIMIZE_OFF
 	void DirectXDevice::SetDisableError(bool disable) {
 		disableError_ = disable;
-		DebugLog(std::format("Disable Error : {}\n", disableError_ ? "true" : "false"));
+		QFE_LOG(std::format("Disable Error : {}\n", disableError_ ? "true" : "false"));
 	}
 	void DirectXDevice::SetDisableWarning(bool disable) {
 		disableWarning_ = disable;
-		DebugLog(std::format("Disable Warning : {}\n", disableWarning_ ? "true" : "false"));
+		QFE_LOG(std::format("Disable Warning : {}\n", disableWarning_ ? "true" : "false"));
 	}
 #endif // QFE_OPTIMIZE_OFF
 
@@ -98,7 +98,7 @@ namespace QFE {
 			if (!(adapterDesc.Flags & DXGI_ADAPTER_FLAG3_SOFTWARE)) {
 				// 採用したアダプタの情報をログに出力。
 #ifdef QFE_OPTIMIZE_OFF
-				DebugLog(ConvertString(std::format(L"Use Adapter:{}\n", adapterDesc.Description)));
+				QFE_LOG(ConvertString(std::format(L"Use Adapter:{}\n", adapterDesc.Description)));
 #endif // QFE_OPTIMIZE_OFF
 				break;
 			}
@@ -128,7 +128,7 @@ namespace QFE {
 			if (SUCCEEDED(hr)) {
 				// 生成できたのでログ出力してループ脱出
 #ifdef QFE_OPTIMIZE_OFF
-				DebugLog(std::format("FeatureLevel : {}\n", featureLevelStrings[i]));
+				QFE_LOG(std::format("FeatureLevel : {}\n", featureLevelStrings[i]));
 #endif // QFE_OPTIMIZE_OFF
 				break;
 			}
@@ -137,31 +137,31 @@ namespace QFE {
 		assert(device_ != nullptr);
 
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog("Complete create D3D12Device");
+		QFE_LOG("Complete create D3D12Device");
 #endif // QFE_OPTIMIZE_OFF
 
 		// エラー落ち処理
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog("---EnebleBreakOnSeverity---");
+		QFE_LOG("---EnebleBreakOnSeverity---");
 		ID3D12InfoQueue* infoQueue = nullptr;
 		if (SUCCEEDED(device_->QueryInterface(IID_PPV_ARGS(&infoQueue)))) {
 
 			// ヤバエラー落ち
 			infoQueue->SetBreakOnSeverity(D3D12_MESSAGE_SEVERITY_CORRUPTION, true);
-			DebugLog("EnebleBreakOnSeverity_CORRUPTION");
+			QFE_LOG("EnebleBreakOnSeverity_CORRUPTION");
 			// エラー落ち
 			if (disableError_) {
-				DebugLog("!!! DisableBreakOnSeverity_ERROR !!!");
+				QFE_LOG("!!! DisableBreakOnSeverity_ERROR !!!");
 			} else {
 				infoQueue->SetBreakOnSeverity(D3D12_MESSAGE_SEVERITY_ERROR, true);
-				DebugLog("EnebleBreakOnSeverity_ERROR");
+				QFE_LOG("EnebleBreakOnSeverity_ERROR");
 			}
 			// 警告
 			if (disableWarning_) {
-				DebugLog("!!! DisableBreakOnSeverity_WARNING !!!");
+				QFE_LOG("!!! DisableBreakOnSeverity_WARNING !!!");
 			} else {
 				infoQueue->SetBreakOnSeverity(D3D12_MESSAGE_SEVERITY_WARNING, true);
-				DebugLog("EnebleBreakOnSeverity_WARNING");
+				QFE_LOG("EnebleBreakOnSeverity_WARNING");
 			}
 
 			// エラー抑制

--- a/project/engine/src/graphic/Pipeline/PSO/RootParameter.cpp
+++ b/project/engine/src/graphic/Pipeline/PSO/RootParameter.cpp
@@ -35,7 +35,7 @@ void RootParameter::SetDescriptorRange(const std::string& friendlyName, const D3
 	D3D12_ROOT_PARAMETER* rootParameter = GetRootParameter(friendlyName);
 	if (rootParameter == nullptr) {
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog("RootParameter: RootParameter not found for the given friendly name.");
+		QFE_LOG("RootParameter: RootParameter not found for the given friendly name.");
 #endif // QFE_OPTIMIZE_OFF
 		assert(false && "RootParameter not found for the given friendly name.");
 		return;
@@ -51,7 +51,7 @@ void RootParameter::SetDescriptorRange(const std::string& friendlyName, const D3
 
 #ifdef QFE_OPTIMIZE_OFF
 	if (rootParameter->ParameterType != D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE) {
-		DebugLog("RootParameter: ParameterType is Not TableType! ChangedType->D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE");
+		QFE_LOG("RootParameter: ParameterType is Not TableType! ChangedType->D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE");
 	}
 #endif // QFE_OPTIMIZE_OFF
 
@@ -63,19 +63,19 @@ void RootParameter::SetDescriptorRange(const std::string& friendlyName, const D3
 
 #ifdef QFE_OPTIMIZE_OFF
 void RootParameter::CheckIntegrityData() {
-	DebugLog("RootParameter: CheckIntegrityData");
+	QFE_LOG("RootParameter: CheckIntegrityData");
 
 	// 郢晢ｽｫ郢晢ｽｼ郢晏現繝ｱ郢晢ｽｩ郢晢ｽ｡郢晢ｽｼ郢ｧ・ｿ邵ｺ謔滂ｽｮ螟ゑｽｾ・ｩ邵ｺ霈費ｽ檎ｸｺ・ｦ邵ｺ繝ｻ竊醍ｸｺ繝ｻ・ｰ・ｴ陷ｷ蛹ｻ繝ｻ郢晢ｽｭ郢ｧ・ｰ郢ｧ雋槭・陷峨・
 	if (rootParameters_.empty()) {
-		DebugLog("RootParameter: No root parameters defined.");
+		QFE_LOG("RootParameter: No root parameters defined.");
 		return;
 	}
-	DebugLog("RootParameter: Integrity check completed successfully.");
+	QFE_LOG("RootParameter: Integrity check completed successfully.");
 
-	DebugLog("RootParameter: ===ParameterList===");
+	QFE_LOG("RootParameter: ===ParameterList===");
 	for (const std::string& name : friendlyNames_) {
 		D3D12_ROOT_PARAMETER* rootParameter = GetRootParameter(name);
-		DebugLog(DirectXStructToString::ToString(*rootParameter));
+		QFE_LOG(DirectXStructToString::ToString(*rootParameter));
 	}
 }
 #endif // QFE_OPTIMIZE_OFF
@@ -91,7 +91,7 @@ D3D12_ROOT_PARAMETER* RootParameter::GetRootParameter(const std::string& friendl
 			assert(index < rootParameters_.size() && "Index out of bounds for root parameters.");
 			result = &rootParameters_[index];
 #ifdef QFE_OPTIMIZE_OFF
-			DebugLog(std::format("RootParameter: Return {}", friendlyNames_[index]));
+			QFE_LOG(std::format("RootParameter: Return {}", friendlyNames_[index]));
 #endif // QFE_OPTIMIZE_OFF
 			return result;
 		} 

--- a/project/engine/src/graphic/Pipeline/PSO/ShaderCompiler.cpp
+++ b/project/engine/src/graphic/Pipeline/PSO/ShaderCompiler.cpp
@@ -20,7 +20,7 @@ ShaderCompiler::ShaderCompiler() {
 
 ShaderCompiler::~ShaderCompiler() {
 #ifdef QFE_OPTIMIZE_OFF
-	DebugLog("=====ShaderFiles=====");
+	QFE_LOG("=====ShaderFiles=====");
 #endif // QFE_OPTIMIZE_OFF
 
 	// iDxcBlobMap_縺ｫ譬ｼ邏阪＆繧後※縺・ｋIDxcBlob*繧坦elease縺励※隗｣謾ｾ
@@ -28,13 +28,13 @@ ShaderCompiler::~ShaderCompiler() {
 		if (blob) {
 			blob->Release();
 #ifdef QFE_OPTIMIZE_OFF
-			DebugLog(std::format("Delete: {}", ConvertString(key)));
+			QFE_LOG(std::format("Delete: {}", ConvertString(key)));
 #endif // QFE_OPTIMIZE_OFF
 		}
 	}
 	iDxcBlobMap_.clear();
 #ifdef QFE_OPTIMIZE_OFF
-	DebugLog("=====================");
+	QFE_LOG("=====================");
 #endif // QFE_OPTIMIZE_OFF
 }
 
@@ -57,7 +57,7 @@ IDxcBlob* ShaderCompiler::CompileShader(const std::wstring& filePath, const wcha
 	// 縺吶〒縺ｫ繧ｳ繝ｳ繝代う繝ｫ貂医∩縺ｪ繧峨く繝｣繝・す繝･縺九ｉ蜿門ｾ・
 	if (iDxcBlobMap_.contains(filePath)) {
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog(std::format("Loaded file: {}", ConvertString(filePath)));
+		QFE_LOG(std::format("Loaded file: {}", ConvertString(filePath)));
 #endif // QFE_OPTIMIZE_OFF
 		return iDxcBlobMap_.at(filePath);
 	}

--- a/project/engine/src/graphic/Pipeline/PSO/ShaderReflection.cpp
+++ b/project/engine/src/graphic/Pipeline/PSO/ShaderReflection.cpp
@@ -128,7 +128,7 @@ nlohmann::json ShaderReflection::Serialize() const {
 	{
 		e;
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog("ShaderReflection::Serialize: Exception occurred - " + std::string(e.what()));
+		QFE_LOG("ShaderReflection::Serialize: Exception occurred - " + std::string(e.what()));
 #endif // =DEBUG
 
 	}

--- a/project/engine/src/graphic/ShaderBuffer/BufferGenerater/BufferGenerator.cpp
+++ b/project/engine/src/graphic/ShaderBuffer/BufferGenerater/BufferGenerator.cpp
@@ -28,7 +28,7 @@ Microsoft::WRL::ComPtr<ID3D12Resource> BufferGenerator::Generate(ID3D12Device* d
 	assert(SUCCEEDED(hr));
 
 #ifdef QFE_OPTIMIZE_OFF
-	DebugLog(ConvertString(std::format(L"CreateBufferResource Bytes = {}", sizeInBytes)));
+	QFE_LOG(ConvertString(std::format(L"CreateBufferResource Bytes = {}", sizeInBytes)));
 #endif // QFE_OPTIMIZE_OFF
 	return vertexResource;
 }

--- a/project/engine/src/input/KeyConfig.cpp
+++ b/project/engine/src/input/KeyConfig.cpp
@@ -91,7 +91,7 @@ namespace QFE {
 		}
 
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog("GetKeys: No keys found for action '" + name + "'", LogLevel::Error);
+		QFE_LOG("GetKeys: No keys found for action '" + name + "'", LogLevel::Error);
 #endif // QFE_OPTIMIZE_OFF
 		return emptyVector;
 	}
@@ -146,7 +146,7 @@ namespace QFE {
 		catch (const std::exception& e) {
 			e;
 #ifdef QFE_OPTIMIZE_OFF
-			DebugLog(std::string("Error: ") + e.what(), LogLevel::EditorInfo);
+			QFE_LOG(std::string("Error: ") + e.what(), LogLevel::EditorInfo);
 #endif // QFE_OPTIMIZE_OFF
 		}
 	}
@@ -174,7 +174,7 @@ namespace QFE {
 		catch (const std::exception& e) {
 			e;
 #ifdef QFE_OPTIMIZE_OFF
-			DebugLog(std::string("Error: ") + e.what(), LogLevel::EditorInfo);
+			QFE_LOG(std::string("Error: ") + e.what(), LogLevel::EditorInfo);
 #endif // QFE_OPTIMIZE_OFF
 		}
 	}

--- a/project/engine/src/input/XInput/XInputController.cpp
+++ b/project/engine/src/input/XInput/XInputController.cpp
@@ -30,25 +30,25 @@ namespace QFE {
 				if (!gamepadStates[i].isConnected) {
 					gamepadStates[i].isConnected = true;
 #ifdef QFE_OPTIMIZE_OFF
-					DebugLog(std::format("Connected Controller! paletNumber: {}", gamepadStates[i].state.dwPacketNumber));
+					QFE_LOG(std::format("Connected Controller! paletNumber: {}", gamepadStates[i].state.dwPacketNumber));
 
 					// 機能情報を取得
 					XINPUT_CAPABILITIES cap;
 					if (XInputGetCapabilities(i, 0, &cap) == ERROR_SUCCESS) {
-						DebugLog(std::format("Type: {}", static_cast<int>(cap.Type)));
-						DebugLog(std::format("SubType: {}", static_cast<int>(cap.SubType)));
-						DebugLog(std::format("Flags: 0x{:X}", static_cast<unsigned int>(cap.Flags)));
+						QFE_LOG(std::format("Type: {}", static_cast<int>(cap.Type)));
+						QFE_LOG(std::format("SubType: {}", static_cast<int>(cap.SubType)));
+						QFE_LOG(std::format("Flags: 0x{:X}", static_cast<unsigned int>(cap.Flags)));
 					} else {
-						DebugLog("Failed to get capabilities.");
+						QFE_LOG("Failed to get capabilities.");
 					}
 
 					// バッテリー情報を取得
 					XINPUT_BATTERY_INFORMATION batteryInfo;
 					if (XInputGetBatteryInformation(i, BATTERY_DEVTYPE_GAMEPAD, &batteryInfo) == ERROR_SUCCESS) {
-						DebugLog(std::format("Battery Type: {}", static_cast<int>(batteryInfo.BatteryType)));
-						DebugLog(std::format("Battery Level: {}", static_cast<int>(batteryInfo.BatteryLevel)));
+						QFE_LOG(std::format("Battery Type: {}", static_cast<int>(batteryInfo.BatteryType)));
+						QFE_LOG(std::format("Battery Level: {}", static_cast<int>(batteryInfo.BatteryLevel)));
 					} else {
-						DebugLog("Failed to get battery information.");
+						QFE_LOG("Failed to get battery information.");
 					}
 #endif // QFE_OPTIMIZE_OFF
 				}

--- a/project/engine/src/renderer/GraphRenderer.cpp
+++ b/project/engine/src/renderer/GraphRenderer.cpp
@@ -162,7 +162,7 @@ void GraphRenderer::Finalize() {
 void GraphRenderer::DrawTriangle(Vector3 point1, Vector3 point2, Vector3 point3, const Vector4& color) {
 	if (triangleCount_ >= kGraphRendererMaxTriangleCount) {
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog("Exceeded maximum triangle count.");
+		QFE_LOG("Exceeded maximum triangle count.");
 #endif // QFE_OPTIMIZE_OFF
 		return; // 譛螟ｧ謨ｰ繧定ｶ・∴縺溷ｴ蜷医・謠冗判縺励↑縺・
 	}
@@ -190,7 +190,7 @@ void GraphRenderer::DrawTriangle(Vector3 point1, Vector3 point2, Vector3 point3,
 void GraphRenderer::DrawLine(Vector3 point1, Vector3 point2, const Vector4& color) {
 	if (lineCount_ >= kGraphRendererMaxLineCount) {
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog("Exceeded maximum Line count.");
+		QFE_LOG("Exceeded maximum Line count.");
 #endif // QFE_OPTIMIZE_OFF
 		return; // 譛螟ｧ謨ｰ繧定ｶ・∴縺溷ｴ蜷医・謠冗判縺励↑縺・
 	}
@@ -210,7 +210,7 @@ void GraphRenderer::DrawLine(Vector3 point1, Vector3 point2, const Vector4& colo
 void GraphRenderer::DrawPoint(Vector3 point, const Vector4& color) {
 	if (pointCount_ >= kGraphRendererMaxPointCount) {
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog("Exceeded maximum Points count.");
+		QFE_LOG("Exceeded maximum Points count.");
 #endif // QFE_OPTIMIZE_OFF
 		return; // 譛螟ｧ謨ｰ繧定ｶ・∴縺溷ｴ蜷医・謠冗判縺励↑縺・
 	}

--- a/project/engine/src/renderer/ModelRenderer.cpp
+++ b/project/engine/src/renderer/ModelRenderer.cpp
@@ -32,7 +32,7 @@ namespace QFE {
 				const ModelRenderData* modelDataPtr = assetManager->GetModelRenderData(modelHandle);
 				if(modelDataPtr == nullptr) {
 #ifdef QFE_OPTIMIZE_OFF
-					DebugLog(std::string("Error: ModelRenderData is nullptr for modelHandle ") + std::to_string(modelHandle));
+					QFE_LOG(std::string("Error: ModelRenderData is nullptr for modelHandle ") + std::to_string(modelHandle));
 #endif // QFE_OPTIMIZE_OFF
 					return;
 				}

--- a/project/engine/src/scene/SceneCommand/SceneEntityCommandInvoker.cpp
+++ b/project/engine/src/scene/SceneCommand/SceneEntityCommandInvoker.cpp
@@ -34,7 +34,7 @@ void SceneEntityCommandInvoker::ExecuteCommands() {
 		float elapsedTime = std::chrono::duration<float>(currentTime - startTime).count();
 		if (elapsedTime >= commandTimeout_) {
 #ifdef QFE_OPTIMIZE_OFF
-			DebugLog("SceneEntityCommandInvoker: User command execution timed out.", LogLevel::Warning);
+			QFE_LOG("SceneEntityCommandInvoker: User command execution timed out.", LogLevel::Warning);
 #endif // QFE_OPTIMIZE_OFF
 			break;
 		}

--- a/project/engine/src/scene/SceneManager.cpp
+++ b/project/engine/src/scene/SceneManager.cpp
@@ -31,13 +31,13 @@ void SceneManager::Initialize() {
 			ifs.close();
 		}
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog("Load SceneConfig.json");
+		QFE_LOG("Load SceneConfig.json");
 #endif // QFE_OPTIMIZE_OFF
 	}
 	catch (const std::exception& e) {
 		e;
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog(std::string("Error: ") + e.what(), LogLevel::EditorInfo);
+		QFE_LOG(std::string("Error: ") + e.what(), LogLevel::EditorInfo);
 #endif // QFE_OPTIMIZE_OFF
 	}
 
@@ -109,10 +109,10 @@ void SceneManager::Finalize() {
 		std::ofstream ofs(path);
 		ofs << sceneConfig_.dump(4);
 		ofs.close();
-		DebugLog("SaveSceneConfig");
+		QFE_LOG("SaveSceneConfig");
 	}
 	catch (const std::exception& e) {
-		DebugLog(std::string("Error: ") + e.what(), LogLevel::EditorInfo);
+		QFE_LOG(std::string("Error: ") + e.what(), LogLevel::EditorInfo);
 
 	}
 #endif // QFE_OPTIMIZE_OFF
@@ -249,7 +249,7 @@ void QFE::SceneManager::FirstLoadScene() {
 		catch (const std::exception& e) {
 			e;
 #ifdef QFE_OPTIMIZE_OFF
-			DebugLog(std::string("Error: ") + e.what(), LogLevel::EditorInfo);
+			QFE_LOG(std::string("Error: ") + e.what(), LogLevel::EditorInfo);
 #endif // QFE_OPTIMIZE_OFF
 		}
 	}

--- a/project/engine/src/scene/SceneObject.cpp
+++ b/project/engine/src/scene/SceneObject.cpp
@@ -168,7 +168,7 @@ void SceneObject::LoadScene(const std::string& sceneName) {
 	}
 
 #ifdef QFE_OPTIMIZE_OFF
-	DebugLog("LoadScene: " + sceneNameCopy);
+	QFE_LOG("LoadScene: " + sceneNameCopy);
 #endif // QFE_OPTIMIZE_OFF
 	AssetManager* assetManager = AssetManager::GetInstance();
 	// GPUバッファの解放
@@ -183,7 +183,7 @@ void SceneObject::LoadScene(const std::string& sceneName) {
 	std::ifstream ifs(sceneFilePath + sceneNameCopy);
 	if (!ifs.is_open()) {
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog("Faild load scene: " + sceneNameCopy, LogLevel::Error);
+		QFE_LOG("Faild load scene: " + sceneNameCopy, LogLevel::Error);
 #endif // QFE_OPTIMIZE_OFF
 		CameraManager::GetInstance()->Initialize();
 		return;
@@ -222,7 +222,7 @@ void SceneObject::LoadScene(const std::string& sceneName) {
 
 void SceneObject::SaveScene(const std::string& sceneName) {
 #ifdef QFE_OPTIMIZE_OFF
-	DebugLog("SaveScene: " + sceneName);
+	QFE_LOG("SaveScene: " + sceneName);
 #endif // QFE_OPTIMIZE_OFF
 	AssetManager* assetManager = AssetManager::GetInstance();
 
@@ -245,7 +245,7 @@ void SceneObject::SaveScene(const std::string& sceneName) {
 
 void QFE::SceneObject::SaveSceneBinary(const std::string& sceneName) {
 #ifdef QFE_OPTIMIZE_OFF
-	DebugLog("BinarySaveScene: " + sceneName);
+	QFE_LOG("BinarySaveScene: " + sceneName);
 #endif // QFE_OPTIMIZE_OFF
 	AssetManager* assetManager = AssetManager::GetInstance();
 
@@ -418,7 +418,7 @@ void SceneObject::AddCsharpScript(uint32_t entityId, const std::string& classNam
 		for (const auto& handles : csharpComponent.csharpHandles_) {
 			if (handles.className_ == className) {
 #ifdef QFE_OPTIMIZE_OFF
-				DebugLog("Csharp class " + className + " is already attached to entity " + std::to_string(entityId), LogLevel::Warning);
+				QFE_LOG("Csharp class " + className + " is already attached to entity " + std::to_string(entityId), LogLevel::Warning);
 #endif // QFE_OPTIMIZE_OFF
 				return;
 			}
@@ -434,7 +434,7 @@ void SceneObject::AddCsharpScript(uint32_t entityId, const std::string& classNam
 uint32_t SceneObject::AddEntity(const std::string& entityName) {
 	AssetManager* assetManager = AssetManager::GetInstance();
 #ifdef QFE_OPTIMIZE_OFF
-	DebugLog("AddEntity: " + entityName);
+	QFE_LOG("AddEntity: " + entityName);
 #endif // QFE_OPTIMIZE_OFF
 
 	// リリースビルド時はキャッシュからEntityを読み込む
@@ -453,7 +453,7 @@ uint32_t SceneObject::AddEntity(const std::string& entityName) {
 	if (!ifs.is_open()) {
 		std::string errorMsg = "FaildOpenFile: " + sceneFilePath + entityName;
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog(errorMsg, LogLevel::Error);
+		QFE_LOG(errorMsg, LogLevel::Error);
 #endif // QFE_OPTIMIZE_OFF
 		assert(false && "Faild Open Entity File.");
 	}
@@ -482,7 +482,7 @@ uint32_t SceneObject::RunTimeAddEntity(const std::string& entityName) {
 	}
 	std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
 #ifdef QFE_OPTIMIZE_OFF
-	DebugLog("RunTimeAddEntity Time: " + std::to_string(std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count()) + " ms");
+	QFE_LOG("RunTimeAddEntity Time: " + std::to_string(std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count()) + " ms");
 #endif // QFE_OPTIMIZE_OFF
 	return entityId;
 }
@@ -509,7 +509,7 @@ void SceneObject::ChangeEntityModel(uint32_t entityId, const std::string& modelN
 	// EntityがModelRenderDataを持っていない場合は処理しない
 	if (!entityManager_.HasComponent<ModelHandle>(entityId)) {
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog("ChangeModel entity does not have ModelRenderData", LogLevel::Warning);
+		QFE_LOG("ChangeModel entity does not have ModelRenderData", LogLevel::Warning);
 #endif // QFE_OPTIMIZE_OFF
 		return;
 	}
@@ -525,7 +525,7 @@ void SceneObject::ChangeEntityMesh(uint32_t entityId, const std::string& meshNam
 	//　EntityがModelRenderDataを持っていない、もしくはMeshを持っていない場合は処理しない
 	if (!entityManager_.HasComponent<ModelHandle>(entityId)) {
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog("ChangeMesh entity does not have ModelRenderData", LogLevel::Warning);
+		QFE_LOG("ChangeMesh entity does not have ModelRenderData", LogLevel::Warning);
 #endif // QFE_OPTIMIZE_OFF
 		return;
 	}
@@ -534,7 +534,7 @@ void SceneObject::ChangeEntityMesh(uint32_t entityId, const std::string& meshNam
 	//　Meshがない場合は処理しない
 	if (modelData->meshRenderDataHandles.size() == 0) {
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog("ChangeMesh model does not have mesh", LogLevel::Warning);
+		QFE_LOG("ChangeMesh model does not have mesh", LogLevel::Warning);
 #endif // QFE_OPTIMIZE_OFF
 		return;
 	}
@@ -680,7 +680,7 @@ void SceneObject::DeserializeEntity(uint32_t entityId, const nlohmann::json& ent
 			for (const auto& handle : entityJson["CsharpComponent"]["CsharpHandles"]) {
 				if (handle.contains("ClassName")) {
 #ifdef QFE_OPTIMIZE_OFF
-					DebugLog("Load Csharp Script: " + handle["ClassName"].get<std::string>());
+					QFE_LOG("Load Csharp Script: " + handle["ClassName"].get<std::string>());
 #endif // QFE_OPTIMIZE_OFF
 					AddCsharpScript(entityId, handle["ClassName"].get<std::string>());
 				}

--- a/project/engine/src/utility/DebugTool/App/WinAppDebugCore.cpp
+++ b/project/engine/src/utility/DebugTool/App/WinAppDebugCore.cpp
@@ -12,7 +12,7 @@ WinAppDebugCore::WinAppDebugCore(const LPSTR& lpCmdLine) {
 	SetUnhandledExceptionFilter(ExportDump);
 	lpCmdLine;
 #ifdef QFE_OPTIMIZE_OFF
-	DebugLog("=====WinAppDebugCore=====");
+	QFE_LOG("=====WinAppDebugCore=====");
 #endif // QFE_OPTIMIZE_OFF
 
 	// exe繧定ｵｷ蜍輔＠縺溘ヱ繧ｹ
@@ -23,12 +23,12 @@ WinAppDebugCore::WinAppDebugCore(const LPSTR& lpCmdLine) {
 #ifdef QFE_OPTIMIZE_OFF
 	// 繧ｳ繝槭Φ繝牙ｼ墓焚遒ｺ隱・
 	if (std::strcmp(lpCmdLine, "\0") != 0) {
-		DebugLog("!!! EnebleCommandLineArguments !!!");
-		DebugLog(std::format("EnebleCommand : {}", lpCmdLine));	
+		QFE_LOG("!!! EnebleCommandLineArguments !!!");
+		QFE_LOG(std::format("EnebleCommand : {}", lpCmdLine));	
 	} else {
-		DebugLog("DisableCommandLineArguments");
+		QFE_LOG("DisableCommandLineArguments");
 	}
-	DebugLog("");
+	QFE_LOG("");
 #endif // QFE_OPTIMIZE_OFF
 }
 

--- a/project/engine/src/utility/DebugTool/DebugLog/MyDebugLog.cpp
+++ b/project/engine/src/utility/DebugTool/DebugLog/MyDebugLog.cpp
@@ -117,5 +117,5 @@ void QFE::DebugLog(const std::string& message, const LogLevel& logLevel, const s
 }
 
 void QFE::DebugLogCsharp(const std::string& message) {
-	DebugLog(message, LogLevel::EditorInfo);
+	QFE_LOG(message, LogLevel::EditorInfo);
 }

--- a/project/engine/src/utility/DebugTool/FrameCounter.cpp
+++ b/project/engine/src/utility/DebugTool/FrameCounter.cpp
@@ -6,7 +6,7 @@
 #pragma comment(lib,"winmm.lib") 
 
 #ifdef QFE_OPTIMIZE_OFF
-#include "Engine/include/utility/DebugTool/DebugLog/MyDebugLog.h"
+#include "engine/include/utility/DebugTool/DebugLog/MyDebugLog.h"
 #endif // QFE_OPTIMIZE_OFF
 using namespace QFE;
 namespace {
@@ -22,7 +22,7 @@ void FrameCounter::Initialize() {
 	timeBeginPeriod(1);
 
 #ifdef QFE_OPTIMIZE_OFF
-	DebugLog("FrameCounter Initialized");
+	QFE_LOG("FrameCounter Initialized");
 #endif // QFE_OPTIMIZE_OFF
 
 }

--- a/project/engine/src/utility/DebugTool/ImGui/ImGuiFlameController.cpp
+++ b/project/engine/src/utility/DebugTool/ImGui/ImGuiFlameController.cpp
@@ -7,14 +7,14 @@ using namespace QFE;
 ImGuiFlameController::ImGuiFlameController() {
 #ifdef QFE_OPTIMIZE_OFF
 	stateCheck_ = 0;
-	DebugLog("ImGuiManager : Generate Instance");
+	QFE_LOG("ImGuiManager : Generate Instance");
 #endif // DEBUG
 }
 
 ImGuiFlameController::~ImGuiFlameController() {
 #ifdef QFE_OPTIMIZE_OFF
 	if (stateCheck_ != 0) {
-		DebugLog(std::format("!!! ImGuiManager : Error{} !!!\n", stateCheck_));
+		QFE_LOG(std::format("!!! ImGuiManager : Error{} !!!\n", stateCheck_));
 	}
 #endif // QFE_OPTIMIZE_OFF
 }

--- a/project/engine/src/utility/String/StringLibrary.cpp
+++ b/project/engine/src/utility/String/StringLibrary.cpp
@@ -13,13 +13,13 @@ namespace QFE {
 
 	StringLibrary::~StringLibrary() {
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog(std::format("=====LibraryListLog from {}=====", libraryFriendryName_));
+		QFE_LOG(std::format("=====LibraryListLog from {}=====", libraryFriendryName_));
 		uint32_t index = 0;
 		for (std::string& str : library_) {
-			DebugLog(std::format("Data[{}]: {}", index, str));
+			QFE_LOG(std::format("Data[{}]: {}", index, str));
 			index++;
 		}
-		DebugLog("========================");
+		QFE_LOG("========================");
 #endif // QFE_OPTIMIZE_OFF
 	}
 
@@ -27,19 +27,19 @@ namespace QFE {
 		library_.clear();
 		libraryFriendryName_ = libraryFriendName;
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog(std::format("Create Library Name: {}", libraryFriendryName_));
+		QFE_LOG(std::format("Create Library Name: {}", libraryFriendryName_));
 #endif // QFE_OPTIMIZE_OFF
 	}
 
 	void StringLibrary::AddStringToLibrary(const std::string& string) {
 		if (FindString(string)) {
 #ifdef QFE_OPTIMIZE_OFF
-			DebugLog(std::format("[{}] already loaded.", string));
+			QFE_LOG(std::format("[{}] already loaded.", string));
 #endif // QFE_OPTIMIZE_OFF
 
 		} else {
 #ifdef QFE_OPTIMIZE_OFF
-			DebugLog(std::format("Add string to liblary [{}].", string));
+			QFE_LOG(std::format("Add string to liblary [{}].", string));
 #endif // QFE_OPTIMIZE_OFF
 			library_.push_back(string);
 		}
@@ -49,14 +49,14 @@ namespace QFE {
 		for (std::string& str : library_) {
 			if (str == string) {
 #ifdef QFE_OPTIMIZE_OFF
-				DebugLog(std::format("Find [{}].", string));
+				QFE_LOG(std::format("Find [{}].", string));
 #endif // QFE_OPTIMIZE_OFF
 				return true;
 			}
 		}
 
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog(std::format("Not find [{}].", string));
+		QFE_LOG(std::format("Not find [{}].", string));
 #endif // QFE_OPTIMIZE_OFF
 		return false;
 	}
@@ -66,7 +66,7 @@ namespace QFE {
 		for (std::string& str : library_) {
 			if (str == string) {
 #ifdef QFE_OPTIMIZE_OFF
-				DebugLog(std::format("Find {} Index: [{}].", string, indexCount));
+				QFE_LOG(std::format("Find {} Index: [{}].", string, indexCount));
 #endif // QFE_OPTIMIZE_OFF
 				return indexCount;
 			}

--- a/project/engine/src/window/WindowEventsManager/EventSystems/DropFileEvent.cpp
+++ b/project/engine/src/window/WindowEventsManager/EventSystems/DropFileEvent.cpp
@@ -10,7 +10,7 @@ DropFileEvent::DropFileEvent(nlohmann::json& data):IEvent(data) {}
 void DropFileEvent::OnEvent(WPARAM wparam, LPARAM lparam) {
 	lparam;
 #ifdef QFE_OPTIMIZE_OFF
-	DebugLog("Call DropFileEvent");
+	QFE_LOG("Call DropFileEvent");
 #endif // QFE_OPTIMIZE_OFF
 
 	// ドロップされたファイルのパスを取得
@@ -22,7 +22,7 @@ void DropFileEvent::OnEvent(WPARAM wparam, LPARAM lparam) {
 		// ファイルパスをイベントデータに格納
 		eventData_["DropFilePath"] = ConvertString(filePath);
 #ifdef QFE_OPTIMIZE_OFF
-		DebugLog("Drop File: " + ConvertString(filePath));
+		QFE_LOG("Drop File: " + ConvertString(filePath));
 #endif // QFE_OPTIMIZE_OFF
 	}
 	DragFinish(hDrop);

--- a/project/engine/src/window/WindowEventsManager/EventSystems/ExitAppEvent.cpp
+++ b/project/engine/src/window/WindowEventsManager/EventSystems/ExitAppEvent.cpp
@@ -10,7 +10,7 @@ void ExitAppEvent::OnEvent(WPARAM wparam, LPARAM lparam) {
 	wparam; // Unused parameter
 	lparam; // Unused parameter
 #ifdef QFE_OPTIMIZE_OFF
-	DebugLog("Call ExitAppEvent");
+	QFE_LOG("Call ExitAppEvent");
 #endif
 	// アプリケーション終了フラグを立てる
 	eventData_["DestroyWindow"] = true;

--- a/project/engine/src/window/WindowEventsManager/EventSystems/OnFocusEvent.cpp
+++ b/project/engine/src/window/WindowEventsManager/EventSystems/OnFocusEvent.cpp
@@ -14,7 +14,7 @@ OnFocusEvent::OnFocusEvent(nlohmann::json& data) :IEvent(data) {}
 void OnFocusEvent::OnEvent(WPARAM wparam, LPARAM lparam) {
 	wparam; lparam;
 #ifdef QFE_OPTIMIZE_OFF
-	DebugLog("Whindow Focused");
+	QFE_LOG("Whindow Focused");
 #endif // QFE_OPTIMIZE_OFF
 	
 }

--- a/project/engine/src/window/WindowEventsManager/WindowEventsManager.cpp
+++ b/project/engine/src/window/WindowEventsManager/WindowEventsManager.cpp
@@ -1,4 +1,4 @@
-﻿#include "engine/include/window/windowEventsManager/WindowEventsManager.h"
+#include "engine/include/window/windowEventsManager/WindowEventsManager.h"
 
 #include "engine/include/window/windowEventsManager/eventSystems/DropFileEvent.h"
 #include "engine/include/window/windowEventsManager/eventSystems/ExitAppEvent.h"
@@ -51,7 +51,7 @@ namespace QFE {
 		for (const auto& eventSystem : eventSystems_) {
 			if (eventSystem && msg == eventSystem->GetEventType()) {
 #ifdef QFE_OPTIMIZE_OFF
-				DebugLog("Call Event WindowName: " + ConvertString(HwndConvertString::HwndToString(hwnd)));
+				QFE_LOG("Call Event WindowName: " + ConvertString(HwndConvertString::HwndToString(hwnd)));
 #endif
 				eventSystem->OnEvent(wparam, lparam);
 				return 0;


### PR DESCRIPTION
- 既存のDebugLog呼び出しを全てQFE_LOGマクロに置換
- QFE_LOGはQFE_OPTIMIZE_OFF時のみログ出力、最適化時は無効化
- MyDebugLog.hにQFE_LOGマクロを追加し、ifdefによる分岐を簡素化
- コメント・ドキュメントを日本語で整理、マクロ利用方法を明記
- DebugLogCsharpもQFE_LOGを利用するよう修正
- インクルードパスやビルド情報（BUILD_COMMIT等）も更新
- ログ出力制御の一元化により保守性・可読性を向上