### PR TITLE
C#スクリプト再コンパイル処理をBridge経由に統合

### DIFF
--- a/project/editor/src/UI/UIManager.cpp
+++ b/project/editor/src/UI/UIManager.cpp
@@ -5,7 +5,7 @@
 
 #include "editor/include/UI/UIManager.h"
 #include "engine/include/assets/AssetManager.h"
-#include "engine/include/core/Bridge/EditorEngineBridge.h"
+#include "engine/include/core/Bridge/EngineBridgeProvider.h"
 
 #include "engine/include/graphic/PostEffect/RenderingPostprocess.h"
 #include "engine/include/scene/SceneManager.h"
@@ -149,7 +149,8 @@ void UIManager::Draw() {
 
 		// C#を再コンパイルするボタン
 		if (ImGui::Button("Recompile C#")) {
-			EditorEngineBridge::ReCompileCsharpScripts();
+			IEngineBridge* engineBridge = QFE::BRIDGE::GetBridge();
+			engineBridge->ReCompileCsharpScripts();
 		}
 
 		ImGui::EndMainMenuBar();

--- a/project/engine/BuildInfo.h
+++ b/project/engine/BuildInfo.h
@@ -1,5 +1,5 @@
 #pragma once 
-#define BUILD_COMMIT "14452701" 
-#define BUILD_BRANCH "refactor-Bridge" 
+#define BUILD_COMMIT "546d7b52" 
+#define BUILD_BRANCH "develop" 
 #define BUILD_DATE "2026/05/07" 
-#define BUILD_TIME "06:28:34.87" 
+#define BUILD_TIME "08:28:20.93" 

--- a/project/engine/include/core/Bridge/IEngineBridge.h
+++ b/project/engine/include/core/Bridge/IEngineBridge.h
@@ -59,6 +59,7 @@ namespace QFE {
 		virtual void SetAABBColliderInfo(uint32_t entityId, const AABBColliderInfo& colliderInfo) = 0;
 
 		// スクリプト操作
+		virtual void ReCompileCsharpScripts() = 0;
 		virtual std::vector<std::string> GetCsharpClassNames(uint32_t entityId) = 0;
 		virtual void RemoveCsharpScript(uint32_t entityId, const std::string& className) = 0;
 		virtual void AddCsharpScript(uint32_t entityId, const std::string& className) = 0;

--- a/project/engine/include/core/Bridge/WindowsBridgeCore.h
+++ b/project/engine/include/core/Bridge/WindowsBridgeCore.h
@@ -65,6 +65,7 @@ namespace QFE {
 		virtual std::vector<std::string> GetAvailableCsharpClasses() override;
 
 		// シーンにエンティティを追加する関数群
+		virtual void ReCompileCsharpScripts() override;
 		virtual void AddEmptyEntity() override;
 		virtual void AddEntityFromFile(const std::string& filepath) override;
 		virtual void AddModelEntity(const std::string& filepath) override;

--- a/project/engine/src/assets/Script/QFElinker/CsharpOnQFELinker.cpp
+++ b/project/engine/src/assets/Script/QFElinker/CsharpOnQFELinker.cpp
@@ -153,7 +153,9 @@ void QFE::CsharpOnQFELinker::StopSound(uint32_t playHandle) {
 
 uint32_t QFE::CsharpOnQFELinker::GetEntity(MonoString* entityName)
 {
-	return SceneManager::GetInstance()-
+	std::string utf8_entityName = mono_string_to_utf8(entityName);
+	uint32_t entityId = SceneManager::GetInstance()->GetEntityByName(utf8_entityName.c_str());
+	return entityId;
 }
 
 uint32_t QFE::CsharpOnQFELinker::CreateEntity(MonoString* entityName) {

--- a/project/engine/src/core/Bridge/WindowsBridgeCore.cpp
+++ b/project/engine/src/core/Bridge/WindowsBridgeCore.cpp
@@ -4,6 +4,7 @@
 #include "engine/include/scene/SceneManager.h"
 #include "engine/include/assets/AssetManager.h"
 #include "engine/include/camera/CameraManager.h"
+#include "engine/include/assets/Script/MonoRuntimeManager.h"
 
 #include "engine/include/scene/Data/SceneObjectData.h"
 #include "engine/include/assets/3DModel/Data/ModelHandle.h"
@@ -421,6 +422,20 @@ namespace QFE {
 			return sceneManager->GetCsharpScriptExecutor()->GetAvailableScriptClasses();
 		}
 		return {};
+	}
+
+	void WindowsBridgeCore::ReCompileCsharpScripts()
+	{
+		QFE_LOG("Recompiling C# scripts...");
+		SceneManager* sceneManager_ = engineCore_->GetSceneManager();
+		if (sceneManager_ && sceneManager_->GetCsharpScriptExecutor()) {
+			MonoRuntimeManager::GetInstance()->CompileScripts();
+			sceneManager_->GetCsharpScriptExecutor()->ReloadAssembly();
+			QFE_LOG("C# scripts recompiled and reloaded.");
+		}
+		else {
+			QFE_LOG("SceneManager or CsharpScriptExecutor is not initialized. Cannot recompile C# scripts.");
+		}
 	}
 
 	void WindowsBridgeCore::AddEmptyEntity() {


### PR DESCRIPTION
- エディタUIの「Recompile C#」ボタン処理をIEngineBridge経由に変更
- IEngineBridgeインターフェースにReCompileCsharpScripts()を追加
- WindowsBridgeCoreでReCompileCsharpScripts()を実装し、MonoRuntimeManagerとCsharpScriptExecutorを利用して再コンパイル・リロードを実現
- 再コンパイル処理に関するログ出力を追加
- CsharpOnQFELinker::GetEntityでMonoStringからUTF-8変換処理を追加
- BuildInfo.hのビルド情報を更新
- 今後の拡張性・プラットフォーム対応性を考慮したリファクタリング