### PR TITLE
C#エンティティ取得/削除API追加とSafeVector強化

### DIFF
--- a/project/engine/BuildInfo.h
+++ b/project/engine/BuildInfo.h
@@ -1,5 +1,5 @@
 #pragma once 
-#define BUILD_COMMIT "546d7b52" 
+#define BUILD_COMMIT "62a62190" 
 #define BUILD_BRANCH "develop" 
 #define BUILD_DATE "2026/05/07" 
-#define BUILD_TIME "08:28:20.93" 
+#define BUILD_TIME "15:08:48.25" 

--- a/project/engine/include/assets/Script/QFElinker/CsharpOnQFELinker.h
+++ b/project/engine/include/assets/Script/QFElinker/CsharpOnQFELinker.h
@@ -40,11 +40,12 @@ namespace QFE::CsharpOnQFELinker {
 	extern void StopSound(uint32_t playHandle);
 
 	// SceneObject
-	extern uint32_t GetEntity(MonoString* entityName);
+	extern uint32_t GetEntityFromName(MonoString* entityName);
 	extern uint32_t CreateEntity(MonoString* entityName);
 	extern void LoadScene(MonoString* sceneName);
     extern void ChangeModel(uint32_t entityId, MonoString* modelName);
     extern void ChangeMesh(uint32_t entityId, MonoString* meshName);
+	extern void DeleteEntity(uint32_t entityId);
 
 	// debug
     extern void Native_Debug_Log(MonoString* message);

--- a/project/engine/include/core/Memory/SafeVector.h
+++ b/project/engine/include/core/Memory/SafeVector.h
@@ -17,17 +17,13 @@ namespace QFE {
 		explicit SafeVector(size_t size = 50) {
 			// std::vectorで確保できるサイズを超えている場合は例外を投げる
 			if (size > data_.max_size()) {
-#ifdef QFE_OPTIMIZE_OFF
 				QFE_LOG(std::string("Data MaxSize: ") + std::to_string(data_.max_size()));
-#endif // QFE_OPTIMIZE_OFF
 				throw std::length_error("SafeVector size exceeds maximum allowed by std::vector.");
 			}
 
 			data_.clear();
 			data_.reserve(size);
-#ifdef QFE_OPTIMIZE_OFF
 			QFE_LOG(std::string("SafeVector initialized with reserved size: ") + std::to_string(size));
-#endif // QFE_OPTIMIZE_OFF
 		}
 
 		/// @brief デストラクタ
@@ -40,6 +36,7 @@ namespace QFE {
 		/// @brief 要素を配列の末尾に追加する（コピーまたはムーブ）
 		virtual void push_back(T value) override {
 			if (data_.size() >= data_.capacity()) {
+				__debugbreak();
 				throw std::overflow_error("SafeVector capacity exceeded. Consider increasing the reserved size.");
 			}
 			data_.push_back(std::move(value));
@@ -120,6 +117,7 @@ namespace QFE {
 			// インデックスが範囲内かどうかをチェック
 			if (index >= data_.size()) {
 				assert(false && "Index out of bounds in SafeVector.");
+				__debugbreak();
 				throw std::out_of_range("Index out of bounds in SafeVector.");
 			}
 		}

--- a/project/engine/src/assets/Script/MonoRuntimeManager.cpp
+++ b/project/engine/src/assets/Script/MonoRuntimeManager.cpp
@@ -146,6 +146,10 @@ void MonoRuntimeManager::RegisterQFEAPI() {
 		(const void*)CsharpOnQFELinker::ChangeModel);
     mono_add_internal_call("QuickForgeEngine.Entity::ChangeMesh", 
 		(const void*)CsharpOnQFELinker::ChangeMesh);
+	mono_add_internal_call("QuickForgeEngine.Entity::GetEntityFromName", 
+		(const void*)CsharpOnQFELinker::GetEntityFromName);
+	mono_add_internal_call("QuickForgeEngine.Entity::Destroy",
+		(const void*)CsharpOnQFELinker::DeleteEntity);
 
 	// Transform関連用APIの登録
 	mono_add_internal_call("QuickForgeEngine.TransformInternal::GetTranslate", 

--- a/project/engine/src/assets/Script/QFElinker/CsharpOnQFELinker.cpp
+++ b/project/engine/src/assets/Script/QFElinker/CsharpOnQFELinker.cpp
@@ -151,8 +151,7 @@ void QFE::CsharpOnQFELinker::StopSound(uint32_t playHandle) {
 	AudioInterface::GetInstance()->StopSound(playHandle);
 }
 
-uint32_t QFE::CsharpOnQFELinker::GetEntity(MonoString* entityName)
-{
+uint32_t QFE::CsharpOnQFELinker::GetEntityFromName(MonoString* entityName) {
 	std::string utf8_entityName = mono_string_to_utf8(entityName);
 	uint32_t entityId = SceneManager::GetInstance()->GetEntityByName(utf8_entityName.c_str());
 	return entityId;
@@ -195,6 +194,10 @@ void QFE::CsharpOnQFELinker::ChangeMesh(uint32_t entityId, MonoString* meshName)
 	char* utf8_meshName = mono_string_to_utf8(meshName);
 	modelData->meshRenderDataHandles[0].vertexBufferHandle = assetManager->LoadModelMesh(utf8_meshName);
 	mono_free(utf8_meshName);
+}
+
+void QFE::CsharpOnQFELinker::DeleteEntity(uint32_t entityId) {
+	SceneManager::GetInstance()->DeleteEntity(entityId);
 }
 
 void QFE::CsharpOnQFELinker::Native_Debug_Log(MonoString* message) {

--- a/project/engine/src/scene/SceneObject.cpp
+++ b/project/engine/src/scene/SceneObject.cpp
@@ -403,8 +403,6 @@ void SceneObject::AddSprite(const std::string& spriteName, float width, float he
 }
 
 void SceneObject::AddCsharpScript(uint32_t entityId, const std::string& className) {
-
-
 	if (!entityManager_.HasComponent<CsharpComponent>(entityId)) {
 		CsharpComponent csharpComponent;
 		CsharpHandle csharpHandle;
@@ -690,18 +688,19 @@ void SceneObject::DeserializeEntity(uint32_t entityId, const nlohmann::json& ent
 }
 
 uint32_t SceneObject::GetEntityByName(const std::string& entityName) const {
-
 	std::vector<uint32_t> entities = entityManager_.GetActiveEntityIds();
 	for (auto entityId : entities) {
 		if (entityManager_.HasComponent<SceneObjectData>(entityId)) {
 			const SceneObjectData& sceneObjectData = entityManager_.GetComponent<SceneObjectData>(entityId);
 			if (sceneObjectData.name == entityName) {
+				QFE_LOG("GetEntityByName: Entity with name \"" + entityName + "\" found. Entity ID: " + std::to_string(entityId));
 				return entityId;
 			}
 		}
 	}
 	assert(false && "Entity Not Found");
-	return 0;
+	QFE_LOG("GetEntityByName: Entity with name \"" + entityName + "\" not found.", LogLevel::Error);
+	return UINT32_MAX;
 }
 
 uint32_t SceneObject::GetEntityByUniqueID(uint32_t uniqueId) const {


### PR DESCRIPTION
C#からエンティティ名で取得・削除できるAPIを追加し、MonoRuntimeManagerで内部呼び出しを登録しました。SafeVectorで例外発生時に__debugbreak()を呼ぶようにし、デバッグ性を向上。エンティティ名取得時の戻り値をUINT32_MAXに変更し、見つからない場合の安全性を強化しました。その他、ビルド情報や細かなコード整理も実施。