### PR TITLE
C#スクリプト管理をSparseSet化＆削除処理を強化

### DIFF
--- a/project/engine/BuildInfo.h
+++ b/project/engine/BuildInfo.h
@@ -1,5 +1,5 @@
 #pragma once 
-#define BUILD_COMMIT "62a62190" 
+#define BUILD_COMMIT "2592bb90" 
 #define BUILD_BRANCH "develop" 
-#define BUILD_DATE "2026/05/07" 
-#define BUILD_TIME "15:08:48.25" 
+#define BUILD_DATE "2026/05/08" 
+#define BUILD_TIME "14:54:28.65" 

--- a/project/engine/include/assets/Script/CsharpScriptExecutor.h
+++ b/project/engine/include/assets/Script/CsharpScriptExecutor.h
@@ -3,7 +3,7 @@
 #include <mono/metadata/assembly.h>
 #include <vector>
 #include <string>
-#include "engine/include/core/Memory/SafeVector.h"
+#include "engine/include/utility/memory/SparseSets.h"
 
 namespace QFE {
 
@@ -55,7 +55,7 @@ namespace QFE {
 		std::vector<std::string> GetAvailableScriptClasses() const;
 
 		/// @brief スクリプト数を取得
-		int GetScriptCount() const { return static_cast<int>(scripts_.size()); }
+		int GetScriptCount() const { return static_cast<int>(scriptInstances_.size()); }
 
 		/// @brief アセンブリをリロード
 		void ReloadAssembly();
@@ -64,7 +64,7 @@ namespace QFE {
 		EntityManager* entityManager_ = nullptr;
 		MonoDomain* domain_ = nullptr;  // このシーン専用のAppDomain
 		MonoAssembly* assembly_ = nullptr;
-		SafeVector<MonoObject*> scripts_;
+		SparseSet<MonoObject*> scriptInstances_; 
 
 		/// @brief アセンブリをロード
 		void LoadAssembly();

--- a/project/engine/include/scene/SceneCommand/DeleteSceneEntityCommand.h
+++ b/project/engine/include/scene/SceneCommand/DeleteSceneEntityCommand.h
@@ -1,12 +1,14 @@
 #pragma once
 #include "ISceneEntityCommand.h"
+#include "engine/include/assets/Script/CsharpScriptExecutor.h"
 #include <nlohmann/json.hpp>
+
 namespace QFE {
 	class DeleteSceneEntityCommand final : public ISceneEntityCommand {
 	public:
 		DeleteSceneEntityCommand() = delete;
 		/// 必ずシーン始めにコマンドを生成すること
-		explicit DeleteSceneEntityCommand(EntityManager& entityManager, uint32_t entityId);
+		explicit DeleteSceneEntityCommand(EntityManager& entityManager, CsharpScriptExecutor& scriptExecutor, uint32_t entityId);
 		~DeleteSceneEntityCommand() override = default;
 
 		/// 指定されたエンティティをシーンから削除する
@@ -18,5 +20,6 @@ namespace QFE {
 	private:
 		uint32_t entityId_;
 		nlohmann::json serializedEntityJson_;
+		CsharpScriptExecutor& scriptExecutor_;
 	};
 }

--- a/project/engine/include/utility/memory/SparseSets.h
+++ b/project/engine/include/utility/memory/SparseSets.h
@@ -7,12 +7,31 @@ namespace QFE {
 	class SparseSet {
 	public:
 		SparseSet() = default;
-		void push_back(const T& value) {
-			uint32_t key = static_cast<uint32_t>(dense_.size());
+		/// @brief キーと値のペアを追加する。キーは自動的に割り当てられる。
+		uint32_t push_back(const T& value) {
+			// 未使用のキー（-1の場所）を探す
+			uint32_t key = 0;
+			while (key < sparse_.size() && sparse_[key] != -1) {
+				key++;
+			}
+			
+			// key に到達するまで push_back でサイズを拡大（空きは -1 で埋める）
+			while (key >= sparse_.size()) {
+				sparse_.push_back(-1);
+			}
+
 			dense_.push_back(value);
 			sparse_[key] = static_cast<int32_t>(dense_.size() - 1);
+			return key;
 		}
+
+		/// @brief キーと値のペアを追加または更新する。キーが存在しない場合は新しいペアを追加し、存在する場合は値を更新する。
 		void Insert(uint32_t key, const T& value) {
+			// 指定された key にアクセスできるようになるまでサイズを広げる
+			while (key >= sparse_.size()) {
+				sparse_.push_back(-1);
+			}
+
 			if (sparse_[key] == -1) {
 				dense_.push_back(value);
 				sparse_[key] = static_cast<int32_t>(dense_.size() - 1);
@@ -20,6 +39,7 @@ namespace QFE {
 				dense_[sparse_[key]] = value;
 			}
 		}
+		/// @brief キーに対応する値を削除する。キーが存在しない場合は何もしない。
 		void Remove(uint32_t key) {
 			if (key < sparse_.size() && sparse_[key] != -1) {
 				int32_t index = sparse_[key];
@@ -34,14 +54,26 @@ namespace QFE {
 				}
 			}
 		}
+		/// @brief キーに対応する値へのポインタを取得する。キーが存在しない場合はnullptrを返す。
 		T* Get(uint32_t key) {
 			if (key < sparse_.size() && sparse_[key] != -1) {
 				return &dense_[sparse_[key]];
 			}
 			return nullptr;
 		}
+		/// @brief キーに対応する要素が存在するかどうかを確認する。
 		bool Contains(uint32_t key) const {
 			return key < sparse_.size() && sparse_[key] != -1;
+		}
+		/// @brief キーの一覧を取得する。
+		std::vector<uint32_t> Keys() const {
+			std::vector<uint32_t> keys;
+			for (uint32_t i = 0; i < sparse_.size(); ++i) {
+				if (sparse_[i] != -1) {
+					keys.push_back(i);
+				}
+			}
+			return keys;
 		}
 
 		// 標準ライブラリ風インターフェース

--- a/project/engine/src/assets/Script/CsharpScriptExecutor.cpp
+++ b/project/engine/src/assets/Script/CsharpScriptExecutor.cpp
@@ -193,10 +193,10 @@ uint32_t CsharpScriptExecutor::CreateScriptInstance(uint32_t entityId, const std
 		}
 	}
 
-	scripts_.push_back(instance);
-	QFE_LOG(std::format("Created C# script instance: {} (index: {})", className, scripts_.size() - 1));
+	uint32_t index = scriptInstances_.push_back(instance);
+	QFE_LOG(std::format("Created C# script instance: {} (index: {})", className, index));
 
-	return static_cast<uint32_t>(scripts_.size()) - 1;
+	return index;
 }
 
 void QFE::CsharpScriptExecutor::CreateScriptInstance(const std::string& className) {
@@ -221,28 +221,28 @@ void QFE::CsharpScriptExecutor::CreateScriptInstance(const std::string& classNam
 	}
 	MonoObject* instance = mono_object_new(domain_, monoClass);
 	mono_runtime_object_init(instance);
-	scripts_.push_back(instance);
+	uint32_t index = scriptInstances_.push_back(instance);
 
-	QFE_LOG(std::format("Create Instance index: {}", static_cast<uint32_t>(scripts_.size()) - 1));
+	QFE_LOG(std::format("Create Instance index: {}", index));
 	return;
 }
 
 void CsharpScriptExecutor::DeleteScriptInstance(uint32_t index) {
-	if (index >= scripts_.size()) {
-		QFE_LOG("Invalid script index: " + std::to_string(index), LogLevel::Error);
+	if (!scriptInstances_.Contains(index)) {
+		QFE_LOG("Script instance at index " + std::to_string(index) + " does not exist.", LogLevel::Warning);
 		return;
 	}
-	scripts_.erase(static_cast<size_t>(index));
+	scriptInstances_.erase(index);
 	QFE_LOG("Deleted script instance at index: " + std::to_string(index));
 }
 
 void CsharpScriptExecutor::RunScriptFunction(uint32_t index, const std::string& functionName) {
-	if (index >= scripts_.size()) {
-		QFE_LOG("Invalid script index: " + std::to_string(index), LogLevel::Error);
+	if (!scriptInstances_.Contains(index)) {
+		QFE_LOG("Script instance at index " + std::to_string(index) + " does not exist.", LogLevel::Warning);
 		return;
 	}
 
-	MonoObject* scriptInstance = scripts_.at(index);
+	MonoObject* scriptInstance = scriptInstances_.at(index);
 	MonoClass* monoClass = mono_object_get_class(scriptInstance);
 	MonoMethod* method = mono_class_get_method_from_name(monoClass, functionName.c_str(), 0);
 
@@ -265,19 +265,20 @@ void CsharpScriptExecutor::RunScriptFunction(uint32_t index, const std::string& 
 }
 
 void CsharpScriptExecutor::RunAllScriptsFunction(const std::string& functionName) {
-	for (size_t i = 0; i < scripts_.size(); ++i) {
-		RunScriptFunction(static_cast<uint32_t>(i), functionName);
-	}
+	std::vector<uint32_t> indices = scriptInstances_.Keys();
+	for (uint32_t index : indices) {
+		RunScriptFunction(index, functionName);
+	}	
 }
 
 void CsharpScriptExecutor::ResetScripts() {
-	scripts_.clear();
+	scriptInstances_.clear();
 	QFE_LOG("All C# scripts reset.");
 }
 
 void CsharpScriptExecutor::ReloadAssembly() {
 	// スクリプトインスタンスをクリア
-	scripts_.clear();
+	scriptInstances_.clear();
 	assembly_ = nullptr;
 
 	// 既存のドメインをアンロード
@@ -310,7 +311,7 @@ void CsharpScriptExecutor::ReloadAssembly() {
 }
 
 void CsharpScriptExecutor::Finalize() {
-	scripts_.clear();
+	scriptInstances_.clear();
 	assembly_ = nullptr;
 
 	if (domain_) {

--- a/project/engine/src/scene/SceneCommand/DeleteSceneEntityCommand.cpp
+++ b/project/engine/src/scene/SceneCommand/DeleteSceneEntityCommand.cpp
@@ -14,11 +14,17 @@
 
 using namespace QFE;
 
-DeleteSceneEntityCommand::DeleteSceneEntityCommand(EntityManager& entityManager, uint32_t entityId)
-:ISceneEntityCommand(entityManager),entityId_(entityId){}
+QFE::DeleteSceneEntityCommand::DeleteSceneEntityCommand(
+	EntityManager& entityManager,
+	CsharpScriptExecutor& scriptExecutor,
+	uint32_t entityId)
+	: ISceneEntityCommand(entityManager), entityId_(entityId), scriptExecutor_(scriptExecutor) {
+}
 
 void DeleteSceneEntityCommand::Execute()
 {
+	QFE_LOG("Executing DeleteSceneEntityCommand for entity " + std::to_string(entityId_));
+
 	// エンティティのコンポーネント情報をシリアライズして保存する
 	serializedEntityJson_ = entityManager_.SerializeEntityComponents(entityId_);
 
@@ -29,9 +35,11 @@ void DeleteSceneEntityCommand::Execute()
 
 	// ModelコンポーネントのGPUリソース解放
 	if (entityManager_.HasComponent<ModelHandle>(entityId_)) {
+		QFE_LOG("Releasing GPU resources for Model component of entity " + std::to_string(entityId_));
 		ModelHandle& modelHandle = entityManager_.GetComponent<ModelHandle>(entityId_);
 		const ModelRenderData* modelData = assetManager->GetModelRenderData(modelHandle.handle);
 		for (const auto& meshData : modelData->meshRenderDataHandles) {
+			QFE_LOG("Releasing GPU resources for MeshRenderDataHandle of entity " + std::to_string(entityId_));
 			gpuBufferPool->ReleaseConstantBuffer<TransformationMatrix>(meshData.wpvBufferHandle);
 			gpuBufferPool->ReleaseConstantBuffer<Material>(meshData.materialHandle);
 			gpuBufferPool->ReleaseConstantBuffer<DirectionalLight>(meshData.lightBufferHandle);
@@ -39,22 +47,25 @@ void DeleteSceneEntityCommand::Execute()
 	}
 	// SpriteコンポーネントのGPUリソース解放
 	if (entityManager_.HasComponent<SpriteData>(entityId_)) {
+		QFE_LOG("Releasing GPU resources for Sprite component of entity " + std::to_string(entityId_));
 		SpriteData& spriteData = entityManager_.GetComponent<SpriteData>(entityId_);
 		gpuBufferPool->ReleaseConstantBuffer<TransformationMatrix>(spriteData.wvpBufferHandle);
 		gpuBufferPool->ReleaseConstantBuffer<Material>(spriteData.materialBufferHandle);
 	}
 
-	// TODO: 関数の復帰
 	// C#Scriptコンポーネントのインスタンス削除
-	/*if (entityManager_.HasComponent<CsharpComponent>(entityId_)) {
-		CsharpVirtualEnvironmentOnQFE* csharpEnv = SceneManager::GetInstance()->GetCsharpScriptExecutor();
-		for (const auto& handle : entityManager_.GetComponent<CsharpComponent>(entityId_).csharpHandles_) {
-			csharpEnv->DeleteScriptInstance(handle.scriptIndex_);
+	if(entityManager_.HasComponent<CsharpComponent>(entityId_)) {
+		QFE_LOG("Deleting C# script instances for entity " + std::to_string(entityId_));
+		CsharpComponent& csharpComponent = entityManager_.GetComponent<CsharpComponent>(entityId_);
+		for (const auto& handle : csharpComponent.csharpHandles_) {
+			scriptExecutor_.DeleteScriptInstance(handle.scriptIndex_);
+			QFE_LOG("Deleted C# script instance: " + handle.className_ + " for entity " + std::to_string(entityId_));
 		}
-	}*/
+	}
 
 	// 指定されたエンティティをシーンから削除する
 	entityManager_.RemoveEntity(entityId_);
+	QFE_LOG("Entity " + std::to_string(entityId_) + " marked for deletion");
 }
 
 void DeleteSceneEntityCommand::Undo()

--- a/project/engine/src/scene/SceneObject.cpp
+++ b/project/engine/src/scene/SceneObject.cpp
@@ -484,7 +484,8 @@ uint32_t SceneObject::RunTimeAddEntity(const std::string& entityName) {
 }
 
 void SceneObject::DeleteEntity(uint32_t entityId) {
-	frameStartCommandInvoker_.AddSystemCommand(std::make_unique<DeleteSceneEntityCommand>(*(GetEntityManager()), entityId));
+	frameStartCommandInvoker_.AddSystemCommand(
+		std::make_unique<DeleteSceneEntityCommand>(entityManager_,csharpScriptExecutor_, entityId));
 }
 
 void SceneObject::CopyEntity(uint32_t sourceEntityId) {


### PR DESCRIPTION
CsharpScriptExecutorのスクリプトインスタンス管理をSafeVectorからSparseSetに変更し、インスタンスの追加・削除・列挙・存在確認APIを拡充しました。DeleteSceneEntityCommandはCsharpScriptExecutor参照を保持し、エンティティ削除時に関連C#スクリプトインスタンスも確実に削除するよう修正。SceneObject::DeleteEntityも対応。これにより、スクリプト管理の堅牢性とリソース解放の確実性が向上しています。

※スクリプトを消すときのハンドル管理を厳格化した