### PR TITLE
デバッグログUIに表示切替・場所別分類機能を追加

### DIFF
--- a/project/editor/include/UI/View/ConsoleView.h
+++ b/project/editor/include/UI/View/ConsoleView.h
@@ -8,7 +8,16 @@
 #ifdef QFE_OPTIMIZE_OFF
 #include "utility/DebugTool/DebugLog/MyDebugLog.h"
 #endif // _DEBUG
+#include <unordered_map>
+#include <functional>
+
 namespace QFE {
+	// ログの表示方法の種類を表す列挙型
+	enum class LogKind {
+		ByLevel,
+		ByLocation
+	};
+
 	/**
 	 * @class ConsoleView
 	 * @brief デバッグログ、警告、エラー等をリスト形式で表示するUI
@@ -24,6 +33,14 @@ namespace QFE {
 		/** @brief 描画 */
 		void Draw() override;
 	private:
+		// ログレベル別の表示をする
+		void DrawLogsByLevel();
+		// クラス、関数ごとに分類されたログを表示する
+		void DrawLogsByLocation();
+
+		LogKind currentLogKind_; // 現在のログ表示方法
+		std::unordered_map<LogKind, std::function<void()>> logDrawFunctions_;// ログ表示方法ごとの描画関数のマップ
+
 #ifdef QFE_OPTIMIZE_OFF
 		LogLevel logLevel_; ///< 表示フィルタリング用のログレベル
 #endif // _DEBUG

--- a/project/editor/src/UI/UIManager.cpp
+++ b/project/editor/src/UI/UIManager.cpp
@@ -139,6 +139,9 @@ void UIManager::Draw() {
 			}
 		} else {
 			if (ImGui::Button(">")) {
+				IEngineBridge* engineBridge = QFE::BRIDGE::GetBridge();
+				engineBridge->ClearRuntimeDebugLogs();
+
 				SceneManager::GetInstance()->StartScript();
 			}
 		}

--- a/project/editor/src/UI/View/ConsoleView.cpp
+++ b/project/editor/src/UI/View/ConsoleView.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "editor/include/UI/View/ConsoleView.h"
+#include "engine/include/core/Bridge/EngineBridgeProvider.h"
 
 #ifdef QFE_OPTIMIZE_OFF
 #include "engine/include/utility/DebugTool/ImGui/ImGuiFlameController.h"
@@ -25,6 +26,9 @@ ConsoleView::ConsoleView() {
  * @brief 初期化処理
  */
 void ConsoleView::Initialize() {
+	logDrawFunctions_[LogKind::ByLevel] = std::bind(&ConsoleView::DrawLogsByLevel, this);
+	logDrawFunctions_[LogKind::ByLocation] = std::bind(&ConsoleView::DrawLogsByLocation, this);
+	currentLogKind_ = LogKind::ByLevel;
 }
 
 /**
@@ -41,7 +45,33 @@ void ConsoleView::Draw() {
 	if (!isActive_) {
 		return;
 	}
-	ImGui::Begin(GetName().c_str(), &isActive_); // Removed &isActive_ from the instruction, but keeping it as the instruction's snippet was partial and this is a common pattern.
+	ImGui::Begin(GetName().c_str(), &isActive_);
+
+	// ログの表示方法切り替え用のコンボボックス
+	ImGui::Text("Display Mode:");
+	ImGui::SameLine();
+	if (ImGui::BeginCombo("##displaymode",
+		currentLogKind_ == LogKind::ByLevel ? "By Level" :
+		currentLogKind_ == LogKind::ByLocation ? "By Location" : "Unknown")) {
+		if (ImGui::Selectable("By Level", currentLogKind_ == LogKind::ByLevel)) {
+			currentLogKind_ = LogKind::ByLevel;
+		}
+		if (ImGui::Selectable("By Location", currentLogKind_ == LogKind::ByLocation)) {
+			currentLogKind_ = LogKind::ByLocation;
+		}
+		ImGui::EndCombo();
+	}
+
+	// 現在の表示方法に応じた描画関数を呼び出す
+	logDrawFunctions_[currentLogKind_]();
+	ImGui::End();
+
+#endif // _DEBUG
+}
+
+void QFE::ConsoleView::DrawLogsByLevel()
+{
+#ifdef QFE_OPTIMIZE_OFF
 	// フォーカス判定
 	ImGui::Text("Log Level:");
 	ImGui::SameLine();
@@ -66,10 +96,11 @@ void ConsoleView::Draw() {
 	}
 	ImGui::SameLine();
 	if (ImGui::Button("Clear")) {
-		MyDebugLog::GetInstance()->DebugLogClear();
+		IEngineBridge* engineBridge = QFE::BRIDGE::GetBridge();
+		engineBridge->ClearRuntimeDebugLogs();
 	}
 	ImGui::Separator();
-	
+
 	ImVec2 logAreaSize = ImGui::GetContentRegionAvail();
 	ImGui::BeginChild("LogArea", logAreaSize, false, ImGuiWindowFlags_HorizontalScrollbar);
 
@@ -110,7 +141,35 @@ void ConsoleView::Draw() {
 		}
 	}
 	ImGui::EndChild();
-	ImGui::End();
+#endif // _DEBUG
+}
 
+void QFE::ConsoleView::DrawLogsByLocation()
+{
+	#ifdef QFE_OPTIMIZE_OFF
+	ImGui::Text("Logs by Location:");
+	ImGui::Separator();
+	for (const auto& [className, funcMap] : MyDebugLog::GetInstance()->locationLogMap_) {
+		if (ImGui::TreeNode(className.c_str())) {
+			for (const auto& [funcName, logs] : funcMap) {
+				if (ImGui::TreeNode(funcName.c_str())) {
+					int logIndex = 0;
+					for (auto it = logs.rbegin(); it != logs.rend(); ++it, ++logIndex) {
+						std::string label = *it + "##log" + std::to_string(logIndex);
+						ImGui::Selectable(label.c_str(), false, ImGuiSelectableFlags_AllowDoubleClick);
+						// 右クリックメニュー追加
+						if (ImGui::BeginPopupContextItem()) {
+							if (ImGui::MenuItem("Copy")) {
+								ImGui::SetClipboardText(it->c_str());
+							}
+							ImGui::EndPopup();
+						}
+					}
+					ImGui::TreePop();
+				}
+			}
+			ImGui::TreePop();
+		}
+	}
 #endif // _DEBUG
 }

--- a/project/engine/BuildInfo.h
+++ b/project/engine/BuildInfo.h
@@ -1,5 +1,5 @@
 #pragma once 
-#define BUILD_COMMIT "ee5c0370" 
+#define BUILD_COMMIT "060c79b7" 
 #define BUILD_BRANCH "develop" 
 #define BUILD_DATE "2026/05/09" 
-#define BUILD_TIME "07:13:04.73" 
+#define BUILD_TIME "17:32:14.33" 

--- a/project/engine/include/core/Bridge/IEngineBridge.h
+++ b/project/engine/include/core/Bridge/IEngineBridge.h
@@ -82,5 +82,6 @@ namespace QFE {
 
 		// デバッグ用の関数群
 		virtual uint32_t GetDebugCameraEntityId() = 0;
+		virtual void ClearRuntimeDebugLogs() = 0;
 	};
 }

--- a/project/engine/include/core/Bridge/WindowsBridgeCore.h
+++ b/project/engine/include/core/Bridge/WindowsBridgeCore.h
@@ -82,6 +82,7 @@ namespace QFE {
 
 		// デバッグ用の関数群
 		virtual uint32_t GetDebugCameraEntityId() override;
+		virtual void ClearRuntimeDebugLogs() override;
 	private:
 		WindowsEngineCore* engineCore_ = nullptr;
 	};

--- a/project/engine/include/utility/DebugTool/DebugLog/MyDebugLog.h
+++ b/project/engine/include/utility/DebugTool/DebugLog/MyDebugLog.h
@@ -5,6 +5,7 @@
 #include <chrono>
 #include <source_location>
 #include <vector>
+#include <deque>
 #include <string>
 #include <unordered_set>
 #include <unordered_map>
@@ -12,7 +13,7 @@
 #include "engine/include/utility/DesignPatterns/Singleton.h"
 
 namespace QFE {
-
+	// ログの種類を表す列挙型.
 	enum class LogLevel {
 		EngineInfo,
 		EditorInfo,
@@ -37,6 +38,8 @@ namespace QFE {
 		const std::vector<std::string>* GetLog();
 		/// @brief 一時的な分類わけされたログを放棄します
 		void DebugLogClear();
+		/// @brief ログの場所ごとに分類されたログを放棄します
+		void ClearLocationLogs();
 
 		// 分類わけされたログ
 		std::vector<std::string> engineLog_;
@@ -46,13 +49,15 @@ namespace QFE {
 
 		// Luaスクリプト別ログ
 		std::unordered_map<uint32_t, std::unordered_map<std::string, std::vector<std::string>>> scriptLogs_;
+
+		// ログの場所ごとに分類されたログ.クラス,関数で分類される.
+		std::unordered_map<std::string, std::unordered_map<std::string, std::deque<std::string>>> locationLogMap_;
 	private:
 		~MyDebugLog() override = default;
 
 		std::ofstream logStream_;
 		std::string logFilePath_;
 		std::vector<std::string> log_;
-
 	};
 
 	/// @brief ログを出力する関数. 最適化オフのときのみ有効.

--- a/project/engine/src/core/Bridge/WindowsBridgeCore.cpp
+++ b/project/engine/src/core/Bridge/WindowsBridgeCore.cpp
@@ -474,9 +474,7 @@ namespace QFE {
 	}
 
 	void WindowsBridgeCore::AddCameraEntity() {
-#ifdef QFE_OPTIMIZE_OFF
-		DebugLog("Can not add Camera.");
-#endif
+		QFE_LOG("Can not add Camera.");
 	}
 
 	void WindowsBridgeCore::CopyEntity(uint32_t entityId) {
@@ -516,12 +514,19 @@ namespace QFE {
 
 	uint32_t WindowsBridgeCore::GetDebugCameraEntityId() {
 		if (!CameraManager::GetInstance()) {
-#ifdef QFE_OPTIMIZE_OFF
-			DebugLog("CameraManager is not initialized.");
-#endif
+			QFE_LOG("CameraManager is not initialized.");
 			return UINT32_MAX;
 		}
 		return CameraManager::GetInstance()->GetCamera(0).GetBindEntityId();
+	}
+
+	void WindowsBridgeCore::ClearRuntimeDebugLogs()
+	{
+#ifdef QFE_OPTIMIZE_OFF
+		QFE_LOG("Clearing runtime debug logs...");
+		MyDebugLog::GetInstance()->DebugLogClear();
+		MyDebugLog::GetInstance()->ClearLocationLogs();
+#endif
 	}
 
 }

--- a/project/engine/src/utility/DebugTool/DebugLog/MyDebugLog.cpp
+++ b/project/engine/src/utility/DebugTool/DebugLog/MyDebugLog.cpp
@@ -13,6 +13,7 @@ void MyDebugLog::Initialize() {
 		editorLog_.clear();
 		warningLog_.clear();
 		errorLog_.clear();
+		locationLogMap_.clear();
 
 		std::filesystem::create_directory("logs");
 		std::chrono::system_clock::time_point now = std::chrono::system_clock::now();
@@ -56,22 +57,33 @@ void MyDebugLog::Finalize() {
 void MyDebugLog::Log(const std::string& message, const std::source_location& location) {
 	try
 	{
+		// ログ出力の際に、時間と関数名を付与する
 		std::chrono::system_clock::time_point now = std::chrono::system_clock::now();
 		std::chrono::time_point<std::chrono::system_clock, std::chrono::seconds>
 			nowSeconds = std::chrono::time_point_cast<std::chrono::seconds>(now);
 		std::chrono::zoned_time localTime{ std::chrono::current_zone(),nowSeconds };
 		std::string timeStamp = std::format("{:%Y-%m-%d_%H-%M-%S}", localTime);
 
-		std::string funcName = location.function_name();
-
+		// ログの保存と、ログファイルへの出力
 		log_.push_back("[" + timeStamp + "] " + message);
 		if (log_.size() > 300) {
 			log_.erase(log_.begin());
 		}
 
+		// 関数名を取得
+		std::string funcName = location.function_name();
+
+		// ログファイルへの出力
 		logStream_ << "[" + timeStamp + "] " + funcName + ": " + message << std::endl;
 		std::string logMessage = message + "\n";
 		OutputDebugStringA(logMessage.c_str());
+
+		// ログの場所ごとに分類されたログに保存
+		std::string className = location.file_name();
+		locationLogMap_[className][funcName].push_back(message);
+		if (locationLogMap_[className][funcName].size() > 300) {
+			locationLogMap_[className][funcName].pop_front();
+		}
 	}
 	catch (const std::exception&)
 	{
@@ -88,6 +100,23 @@ void MyDebugLog::DebugLogClear() {
 	editorLog_.clear();
 	warningLog_.clear();
 	errorLog_.clear();
+}
+
+void QFE::MyDebugLog::ClearLocationLogs()
+{
+	// ログを消す前にどのくらい容量を使っているかを出力する
+	size_t totalSize = 0;
+	for (const auto& [className, funcMap] : locationLogMap_) {
+		for (const auto& [funcName, logs] : funcMap) {
+			totalSize += logs.size();
+		}
+	}
+	// ログを消す前の容量を出力する
+	std::string logMessage = "ClearLocationLogs: totalSize = " + std::to_string(totalSize) + "\n";
+	OutputDebugStringA(logMessage.c_str());
+
+	// ログを消す
+	locationLogMap_.clear();
 }
 
 void QFE::DebugLog(const std::string& message, const LogLevel& logLevel, const std::source_location& location) {


### PR DESCRIPTION
- ConsoleViewにログ表示方法（レベル別/場所別）の切替機能を追加
- ImGuiコンボボックスで表示方法を選択可能に
- MyDebugLogにlocationLogMap_を追加し、クラス・関数ごとにログを自動分類・最大300件保持
- 場所別ログのクリア機能（ClearLocationLogs）を実装し、エンジンブリッジ経由で呼び出し可能に
- スクリプト実行開始時やクリアボタン押下時に全デバッグログを一括クリア
- ConsoleViewの描画処理を表示方法ごとに分離し、場所別表示ではTreeNodeで展開・右クリックコピー対応
- QFE_LOGマクロの利用箇所を整理し、ログ出力の一貫性を向上
- その他、ログ出力時のタイムスタンプ・関数名付与の明確化や不要コード整理など、デバッグログ管理の利便性を改善