### PR TITLE
エンジン全体にプロファイラ機能を導入・可視化対応

### DIFF
--- a/project/editor/src/UI/View/EngineProfileView.cpp
+++ b/project/editor/src/UI/View/EngineProfileView.cpp
@@ -6,6 +6,9 @@
 #include "editor/include/UI/View/EngineProfileView.h"
 
 #include "engine/include/core/EngineGlobalValue.h"
+#include "engine/include/core/Profiler.h"
+#include <map>
+
 #include "engine/BuildInfo.h"
 using namespace QFE;
 EngineProfileView::EngineProfileView() {
@@ -28,7 +31,85 @@ void EngineProfileView::Draw() {
 	ImGui::Text("Engine Profile");
 	ImGui::Separator();
 	
+	// 時間計測の統計を表示
 	ImGui::Text("FPS: %.1f", QFE::EngineGlobalValue::fps);
 	ImGui::Text("DeltaTime: %.3f", QFE::EngineGlobalValue::deltaTime);
+	ImGui::Text("Frame Time: %.3f ms", static_cast<float>(QFE::Profiler::GetInstance()->GetFrameDuration().count()));
+
+	ImGui::Separator();
+	// プロファイルのクリアボタン
+	if(ImGui::Button("Clear Profiles")) {
+		QFE::Profiler::GetInstance()->ClearScopeProfiles();
+	}
+	
+	// スコーププロファイルの統計を表示
+	const auto& scopeProfiles = QFE::Profiler::GetInstance()->GetScopeProfiles();
+
+	// 階層構造を作るための専用ノード構造体
+	struct ProfileNode {
+		std::map<std::string, ProfileNode> children;
+		const std::deque<std::chrono::milliseconds>* durations = nullptr;
+		std::string fullScopeName;
+	};
+
+	ProfileNode rootNode;
+
+	// "::"で区切ってツリーを構築する
+	for (const auto& [scopeName, durations] : scopeProfiles) {
+		ProfileNode* currentNode = &rootNode;
+		size_t start = 0;
+		size_t end = scopeName.find("::");
+
+		while (end != std::string::npos) {
+			std::string part = scopeName.substr(start, end - start);
+			currentNode = &currentNode->children[part];
+			start = end + 2; // "::"の2文字分を進める
+			end = scopeName.find("::", start);
+		}
+		std::string leaf = scopeName.substr(start);
+		currentNode = &currentNode->children[leaf];
+		currentNode->durations = &durations;
+		currentNode->fullScopeName = scopeName; // 平均時間の取得等に使うためのフルネーム
+	}
+
+	// ツリーを再帰的に描画するためのラムダ式 (C++14以降で可)
+	auto DrawProfileNode = [&](auto& self, const std::string& name, const ProfileNode& node) -> void {
+		// 階層を持つか、データを持つ場合のみ表示
+		bool isLeaf = (node.durations != nullptr);
+
+		// 葉ノード（データあり）の場合は少し色を変えたり、フラグを変えることも可能
+		ImGuiTreeNodeFlags flags = isLeaf ? (node.children.empty() ? ImGuiTreeNodeFlags_Leaf : ImGuiTreeNodeFlags_None) : ImGuiTreeNodeFlags_DefaultOpen;
+
+		if (ImGui::TreeNodeEx(name.c_str(), flags)) {
+			// 計測データがある場合はプロファイルの統計を表示
+			if (isLeaf) {
+				ImGui::Text("Latest: %.3f ms (Avg: %.3f ms)",
+					static_cast<float>(node.durations->back().count()),
+					static_cast<float>(QFE::Profiler::GetInstance()->GetAverageScopeDuration(node.fullScopeName).count()));
+
+				// 全体で見たときの割合を表示
+				if (static_cast<float>(QFE::Profiler::GetInstance()->GetFrameDuration().count()) > 0.0f) {
+					float percentage = (static_cast<float>(node.durations->back().count()) / static_cast<float>(QFE::Profiler::GetInstance()->GetFrameDuration().count())) * 100.0f;
+					ImGui::ProgressBar(percentage / 100.0f, ImVec2(0.0f, 0.0f), "");
+				}
+				else {
+					ImGui::Text("No frame duration data available");
+				}
+				ImGui::Spacing();
+			}
+
+			// 子ノードの描画
+			for (const auto& [childName, childNode] : node.children) {
+				self(self, childName, childNode);
+				ImGui::Separator();
+			}
+			ImGui::TreePop();
+		}
+		};
+
+	// ルート直下の子ノードから描画を開始する
+	for (const auto& [childName, childNode] : rootNode.children) {
+		DrawProfileNode(DrawProfileNode, childName, childNode);
+	}
 	ImGui::End();
 }

--- a/project/engine/BuildInfo.h
+++ b/project/engine/BuildInfo.h
@@ -1,5 +1,5 @@
 #pragma once 
-#define BUILD_COMMIT "ee5c0370" 
+#define BUILD_COMMIT "060c79b7" 
 #define BUILD_BRANCH "develop" 
 #define BUILD_DATE "2026/05/09" 
-#define BUILD_TIME "07:13:04.73" 
+#define BUILD_TIME "19:17:37.24" 

--- a/project/engine/include/core/EngineDefines.h
+++ b/project/engine/include/core/EngineDefines.h
@@ -1,0 +1,14 @@
+#pragma once
+#include "engine/include/utility/DebugTool/DebugLog/MyDebugLog.h"
+#include "engine/include/core/Profiler.h"
+
+namespace QFE {
+	// デバッグ用マクロ.最適化オフのときのみログを出力するマクロ. 最適化オンのときは何もしない.
+#ifdef QFE_OPTIMIZE_OFF
+#define QFE_LOG(...) DebugLog(__VA_ARGS__)
+#define QFE_PROFILE_SCOPE ScopeProfile scopeProfile##__LINE__(__FUNCTION__)
+#else
+#define QFE_LOG(...) ((void)0)
+#define QFE_PROFILE_SCOPE ((void)0)
+#endif
+}

--- a/project/engine/include/core/Memory/SafeVector.h
+++ b/project/engine/include/core/Memory/SafeVector.h
@@ -4,9 +4,7 @@
 #include <assert.h>
 #include <stdexcept>
 
-#ifdef QFE_OPTIMIZE_OFF
-#include "engine/include/utility/DebugTool/DebugLog/MyDebugLog.h"
-#endif // QFE_OPTIMIZE_OFF
+#include "engine/include/core/EngineDefines.h"
 
 namespace QFE {
 	/// @brief メモリの連続性とアドレスの不変性を保証するstd::vectorをラップしたクラス

--- a/project/engine/include/core/Profiler.h
+++ b/project/engine/include/core/Profiler.h
@@ -1,0 +1,76 @@
+#pragma once
+#include "engine/include/utility/DesignPatterns/Singleton.h"
+#include <chrono>
+#include <string>
+#include <deque>
+#include <unordered_map>
+#include <source_location>
+
+namespace QFE {
+	/**
+	 * プロファイラークラス.
+	 * コードの実行時間を計測するためのクラスです.
+	 */
+	class Profiler : public Singleton<Profiler> {
+		friend class Singleton<Profiler>;
+	public:
+		/// @brief 初期化処理.
+		void Initialize();
+		/// @brief 終了処理.
+		void Finalize();
+		// / @brief フレーム開始処理.
+		void FrameStart();
+		/// @brief フレーム終了処理.
+		void FrameEnd();
+
+		/// @brief スコーププロファイルをクリアします.
+		void ClearScopeProfiles();
+
+		/// @brief スコーププロファイルを記録します.
+		void RecordScopeProfile(const std::string& scopeName, const std::chrono::milliseconds& duration);
+
+		/// @brief スコーププロファイルを取得します.
+		const std::unordered_map<std::string, std::deque<std::chrono::milliseconds>>& GetScopeProfiles() const;
+		/// @brief フレーム時間を取得します.
+		std::chrono::milliseconds GetFrameDuration() const;
+		/// @brief あるスコープの平均時間を取得します.
+		std::chrono::milliseconds GetAverageScopeDuration(const std::string& scopeName) const;
+
+	private:
+		~Profiler() override = default;
+
+		std::chrono::high_resolution_clock::time_point frameStartTime_;
+		std::chrono::high_resolution_clock::time_point frameEndTime_;
+		std::chrono::milliseconds frameDuration_;
+
+		size_t maxProfileEntries_ = 100;// プロファイルの最大エントリー数. 古いエントリーは削除されます.
+
+		// スコーププロファイルのマップ. スコープ名をキーにしてプロファイルを保存します.
+		std::unordered_map<std::string, std::deque<std::chrono::milliseconds>> scopeProfiles_;
+	};
+
+	/// スコーププロファイルクラス.
+	class ScopeProfile {
+	public:
+		ScopeProfile(const std::string& scopeName) : scopeName_(scopeName) {
+			try {
+				startTime_ = std::chrono::high_resolution_clock::now();
+			}
+			catch (const std::exception&) {}
+		}
+		~ScopeProfile() {
+			try {
+				auto endTime = std::chrono::high_resolution_clock::now();
+				auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(endTime - startTime_);
+				Profiler::GetInstance()->RecordScopeProfile(scopeName_, duration);
+			}
+			catch (const std::exception&) {}
+		}
+
+	private:
+		std::string scopeName_;
+		std::chrono::high_resolution_clock::time_point startTime_;
+	};
+}
+
+

--- a/project/engine/include/graphic/ShaderBuffer/VertexBuffer.h
+++ b/project/engine/include/graphic/ShaderBuffer/VertexBuffer.h
@@ -4,10 +4,7 @@
 #include <cassert>
 #include "engine/resources/Shaders/ShaderStructs/hlslTypeToCpp.h"
 #include "BufferGenerater/BufferGenerator.h"
-
-#ifdef QFE_OPTIMIZE_OFF
-#include "engine/include/utility/DebugTool/DebugLog/MyDebugLog.h"
-#endif
+#include "engine/include/core/EngineDefines.h"
 
 namespace QFE {
 	/// @class VertexBuffer

--- a/project/engine/include/utility/DebugTool/DebugLog/MyDebugLog.h
+++ b/project/engine/include/utility/DebugTool/DebugLog/MyDebugLog.h
@@ -61,12 +61,4 @@ namespace QFE {
 
 	/// @brief C#側から呼び出すためのログ出力関数. 最適化オフのときのみ有効.
 	void DebugLogCsharp(const std::string& message);
-
-	// 最適化オフのときのみログを出力するマクロ. 最適化オンのときは何もしない.
-#ifdef QFE_OPTIMIZE_OFF
-#define QFE_LOG(...) DebugLog(__VA_ARGS__)
-#else
-#define QFE_LOG(...) ((void)0)
-#endif
-
 }

--- a/project/engine/src/WindowsEngineCore.cpp
+++ b/project/engine/src/WindowsEngineCore.cpp
@@ -7,10 +7,12 @@
 
 #include <thread>
 #include "engine/include/utility/DebugTool/ImGui/ImGuiInitializer.h"
+#include "engine/include/core/EngineDefines.h"
 #ifdef QFE_OPTIMIZE_OFF
-#include "engine/include/utility/DebugTool/DebugLog/MyDebugLog.h"
 #include "engine/include/renderer/ModelRenderer.h"
 #endif // QFE_OPTIMIZE_OFF
+#include "engine/include/core/Profiler.h"
+
 #include "engine/include/core/EngineGlobalValue.h"
 #include "engine/include/utility/FileSystems/FileUtility.h"
 
@@ -65,6 +67,9 @@ void QFE::WindowsEngineCore::Initialize(std::unique_ptr<IEngineApp> app) {
 	std::string logInitMessage = "Initialized MyDebugLog. Cache line size: " + std::to_string(std::hardware_destructive_interference_size) + " bytes.";
 	QFE_LOG(logInitMessage);
 #endif // QFE_OPTIMIZE_OFF
+
+	// プロファイラーの初期化
+	Profiler::GetInstance()->Initialize();
 
 	// Create Window
 	gameWindowManager = std::make_unique<GameWindowManager>();
@@ -217,10 +222,12 @@ void WindowsEngineCore::MainLoop() {
 			DispatchMessage(&msg);
 
 		} else {
+			Profiler::GetInstance()->FrameStart();
 			frameCounter_.FrameStart();
 			Update();
 			Draw();
 			frameCounter_.FrameEnd();
+			Profiler::GetInstance()->FrameEnd();
 		}
 	}
 }
@@ -265,6 +272,9 @@ void WindowsEngineCore::Shutdown() {
 	imguiFrameController_.EndImGui();
 	directXCommon_->Shutdown();
 	gameWindowManager->Shutdown();
+
+	Profiler::GetInstance()->Finalize();
+
 #ifdef QFE_OPTIMIZE_OFF
 	QFE_LOG("FinalizeEngine");
 	MyDebugLog::GetInstance()->Finalize();

--- a/project/engine/src/assets/2DTexture/TextureManager.cpp
+++ b/project/engine/src/assets/2DTexture/TextureManager.cpp
@@ -13,8 +13,8 @@
 #include "engine/include/Graphic/DirectXCommon/Descriptors/SrvDescriptorHeap.h"
 #include "engine/include/Graphic/ShaderBuffer/BufferGenerater/BufferGenerator.h"
 
+#include "engine/include/core/EngineDefines.h"
 #ifdef QFE_OPTIMIZE_OFF
-#include "engine/include/utility/DebugTool/DebugLog/MyDebugLog.h"
 #include "engine/include/utility/DebugTool/ImGui/ImGuiInclude.h"
 #endif // QFE_OPTIMIZE_OFF
 

--- a/project/engine/src/assets/3DModel/Loader/AssimpModelLoader.cpp
+++ b/project/engine/src/assets/3DModel/Loader/AssimpModelLoader.cpp
@@ -1,11 +1,8 @@
 #include "engine/include/assets/3DModel/Loader/AssimpModelLoader.h"
 #include "engine/include/utility/FileSystems/FileUtility.h"
 #include <cassert>
-
-#ifdef QFE_OPTIMIZE_OFF
 #include <format>
-#include "engine/include/utility/DebugTool/DebugLog/MyDebugLog.h"
-#endif // QFE_OPTIMIZE_OFF
+#include "engine/include/core/EngineDefines.h"
 
 #include "engine/include/utility/FileSystems/FileUtility.h"
 

--- a/project/engine/src/assets/Animator/AnimClip.cpp
+++ b/project/engine/src/assets/Animator/AnimClip.cpp
@@ -1,7 +1,5 @@
 #include "engine/include/assets/Animator/AnimClip.h"
-#ifdef QFE_OPTIMIZE_OFF
-#include "engine/include/utility/DebugTool/DebugLog/MyDebugLog.h"
-#endif // QFE_OPTIMIZE_OFF
+#include "engine/include/core/EngineDefines.h"
 
 using namespace QFE;
 

--- a/project/engine/src/assets/AudioSource/AudioSourceManager.cpp
+++ b/project/engine/src/assets/AudioSource/AudioSourceManager.cpp
@@ -1,9 +1,9 @@
 #include "engine/include/assets/AudioSource/AudioSourceManager.h"
 #include "engine/include/assets/AudioSource/Loader/MultiAudioLoader.h"
 #include "engine/include/utility/FileSystems/FileUtility.h"
-#ifdef QFE_OPTIMIZE_OFF
-#include "engine/include/utility/DebugTool/DebugLog/MyDebugLog.h"
-#endif // QFE_OPTIMIZE_OFF
+
+#include "engine/include/core/EngineDefines.h"
+
 
 using namespace QFE;
 

--- a/project/engine/src/assets/ResourceDirectoryManager.cpp
+++ b/project/engine/src/assets/ResourceDirectoryManager.cpp
@@ -7,9 +7,7 @@
 #include <cassert>
 #include <filesystem>
 
-#ifdef QFE_OPTIMIZE_OFF
-#include "engine/include/utility/DebugTool/DebugLog/MyDebugLog.h"
-#endif // QFE_OPTIMIZE_OFF
+#include "engine/include/core/EngineDefines.h"
 
 using namespace QFE;
 

--- a/project/engine/src/assets/Script/CsharpCompiler.cpp
+++ b/project/engine/src/assets/Script/CsharpCompiler.cpp
@@ -2,9 +2,8 @@
 #include <fstream>
 #include <sstream>
 #include <iostream>
-#ifdef QFE_OPTIMIZE_OFF
-#include "engine/include/utility/DebugTool/DebugLog/MyDebugLog.h"
-#endif
+
+#include "engine/include/core/EngineDefines.h"
 
 using namespace QFE;
 

--- a/project/engine/src/assets/Script/CsharpScriptExecutor.cpp
+++ b/project/engine/src/assets/Script/CsharpScriptExecutor.cpp
@@ -2,9 +2,7 @@
 #include "engine/include/assets/Script/MonoRuntimeManager.h"
 #include "engine/include/core/Entity/EntityManager.h"
 
-#ifdef QFE_OPTIMIZE_OFF
-#include "engine/include/utility/DebugTool/DebugLog/MyDebugLog.h"
-#endif
+#include "engine/include/core/EngineDefines.h"
 
 #include <format>
 

--- a/project/engine/src/assets/Script/MonoRuntimeManager.cpp
+++ b/project/engine/src/assets/Script/MonoRuntimeManager.cpp
@@ -4,9 +4,7 @@
 #include "engine/include/utility/String/MyString.h"
 #include "engine/include/assets/AssetManager.h"
 
-#ifdef QFE_OPTIMIZE_OFF
-#include "engine/include/utility/DebugTool/DebugLog/MyDebugLog.h"
-#endif
+#include "engine/include/core/EngineDefines.h"
 
 #include <Windows.h>
 #include <filesystem>

--- a/project/engine/src/assets/Script/QFElinker/CsharpOnQFELinker.cpp
+++ b/project/engine/src/assets/Script/QFElinker/CsharpOnQFELinker.cpp
@@ -1,8 +1,6 @@
 #include "engine/include/assets/Script/QFElinker/CsharpOnQFELinker.h"
 
-#ifdef QFE_OPTIMIZE_OFF
-#include "engine/include/utility/DebugTool/DebugLog/MyDebugLog.h"
-#endif // QFE_OPTIMIZE_OFF
+#include "engine/include/core/EngineDefines.h"
 
 #include "engine/include/assets/AssetManager.h"
 #include "engine/include/scene/SceneManager.h"

--- a/project/engine/src/audio/Core/XAudioCore.cpp
+++ b/project/engine/src/audio/Core/XAudioCore.cpp
@@ -20,9 +20,9 @@
 #include <format>
 
 #pragma comment(lib,"xaudio2.lib")
+#include "engine/include/core/EngineDefines.h"
 
 #ifdef QFE_OPTIMIZE_OFF
-#include "engine/include/utility/DebugTool/DebugLog/MyDebugLog.h"
 #include "engine/include/utility/String/MyString.h"
 #endif // QFE_OPTIMIZE_OFF
 using namespace QFE;

--- a/project/engine/src/audio/Player/AudioChipManager.cpp
+++ b/project/engine/src/audio/Player/AudioChipManager.cpp
@@ -1,7 +1,6 @@
 #include "engine/include/audio/Player/AudioChipManager.h"
-#ifdef QFE_OPTIMIZE_OFF
-#include "engine/include/utility/DebugTool/DebugLog/MyDebugLog.h"
-#endif // QFE_OPTIMIZE_OFF
+#include "engine/include/core/EngineDefines.h"
+
 using namespace QFE;
 AudioChipManager::~AudioChipManager() {
 	Finalize();

--- a/project/engine/src/collider/ColliderManager.cpp
+++ b/project/engine/src/collider/ColliderManager.cpp
@@ -10,8 +10,9 @@
 
 #ifdef QFE_OPTIMIZE_OFF
 #include "engine/include/renderer/GraphRenderer.h"
-#include "engine/include/utility/DebugTool/DebugLog/MyDebugLog.h"
 #endif // QFE_OPTIMIZE_OFF
+
+#include "engine/include/core/EngineDefines.h"
 
 #include <algorithm>
 

--- a/project/engine/src/collider/ColliderMask.cpp
+++ b/project/engine/src/collider/ColliderMask.cpp
@@ -3,9 +3,7 @@
 #include <nlohmann/json.hpp> 
 #include <fstream>
 
-#ifdef QFE_OPTIMIZE_OFF
-#include "engine/include/utility/DebugTool/DebugLog/MyDebugLog.h"
-#endif // QFE_OPTIMIZE_OFF
+#include "engine/include/core/EngineDefines.h"
 
 using namespace QFE;
 

--- a/project/engine/src/core/Bridge/WindowsBridgeCore.cpp
+++ b/project/engine/src/core/Bridge/WindowsBridgeCore.cpp
@@ -19,29 +19,32 @@
 #include "engine/include/camera/Data/BillboardComponent.h"
 #include "engine/include/core/Math/ParentData.h"
 
-#ifdef QFE_OPTIMIZE_OFF
-#include "engine/include/utility/DebugTool/DebugLog/MyDebugLog.h"
-#endif
+#include "engine/include/core/EngineDefines.h"
 
 namespace QFE {
 
 	std::string WindowsBridgeCore::GetModelDirectoryPath() {
+		QFE_PROFILE_SCOPE;
 		return engineCore_->GetAssetManager()->GetResourceDirectoryManager()->GetResourceDirectory("Model");
 	}
 
 	std::string WindowsBridgeCore::GetImageDirectoryPath() {
+		QFE_PROFILE_SCOPE;
 		return engineCore_->GetAssetManager()->GetResourceDirectoryManager()->GetResourceDirectory("Image");
 	}
 
 	std::string WindowsBridgeCore::GetEntityTemplateDirectoryPath() {
+		QFE_PROFILE_SCOPE;
 		return engineCore_->GetAssetManager()->GetResourceDirectoryManager()->GetResourceDirectory("Entities");
 	}
 
 	std::string WindowsBridgeCore::GetScriptDirectoryPath() {
+		QFE_PROFILE_SCOPE;
 		return engineCore_->GetAssetManager()->GetResourceDirectoryManager()->GetResourceDirectory("Scripts");
 	}
 
 	std::vector<uint32_t> WindowsBridgeCore::GetAllEntityIds() {
+		QFE_PROFILE_SCOPE;
 		SceneManager* sceneManager = engineCore_->GetSceneManager();
 		if (sceneManager) {
 			return sceneManager->GetEntityManager()->GetActiveEntityIds();
@@ -50,6 +53,7 @@ namespace QFE {
 	}
 
 	std::string WindowsBridgeCore::GetEntityName(uint32_t entityId) {
+		QFE_PROFILE_SCOPE;
 		SceneManager* sceneManager = engineCore_->GetSceneManager();
 		if (sceneManager) {
 			if (sceneManager->GetEntityManager()->HasComponent<SceneObjectData>(entityId)) {
@@ -60,6 +64,7 @@ namespace QFE {
 	}
 
 	void WindowsBridgeCore::SetEntityName(uint32_t entityId, const std::string& name) {
+		QFE_PROFILE_SCOPE;
 		SceneManager* sceneManager = engineCore_->GetSceneManager();
 		if (sceneManager) {
 			if (sceneManager->GetEntityManager()->HasComponent<SceneObjectData>(entityId)) {
@@ -69,6 +74,7 @@ namespace QFE {
 	}
 
 	std::string WindowsBridgeCore::GetEntityTag(uint32_t entityId) {
+		QFE_PROFILE_SCOPE;
 		SceneManager* sceneManager = engineCore_->GetSceneManager();
 		if (sceneManager) {
 			if (sceneManager->GetEntityManager()->HasComponent<SceneObjectData>(entityId)) {
@@ -79,6 +85,7 @@ namespace QFE {
 	}
 
 	void WindowsBridgeCore::SetEntityTag(uint32_t entityId, const std::string& tag) {
+		QFE_PROFILE_SCOPE;
 		SceneManager* sceneManager = engineCore_->GetSceneManager();
 		if (sceneManager) {
 			if (sceneManager->GetEntityManager()->HasComponent<SceneObjectData>(entityId)) {
@@ -88,6 +95,7 @@ namespace QFE {
 	}
 
 	bool WindowsBridgeCore::HasComponent(uint32_t entityId, ComponentType type) {
+		QFE_PROFILE_SCOPE;
 		SceneManager* sceneManager = engineCore_->GetSceneManager();
 		if (!sceneManager) return false;
 		EntityManager* em = sceneManager->GetEntityManager();
@@ -109,6 +117,7 @@ namespace QFE {
 	}
 
 	void WindowsBridgeCore::AddComponent(uint32_t entityId, ComponentType type) {
+		QFE_PROFILE_SCOPE;
 		SceneManager* sceneManager = engineCore_->GetSceneManager();
 		if (!sceneManager) return;
 		EntityManager* em = sceneManager->GetEntityManager();
@@ -125,6 +134,7 @@ namespace QFE {
 	}
 
 	void WindowsBridgeCore::RemoveComponent(uint32_t entityId, ComponentType type) {
+		QFE_PROFILE_SCOPE;
 		SceneManager* sceneManager = engineCore_->GetSceneManager();
 		if (!sceneManager) return;
 		EntityManager* em = sceneManager->GetEntityManager();
@@ -145,6 +155,7 @@ namespace QFE {
 	}
 
 	TransformData WindowsBridgeCore::GetTransform(uint32_t entityId) {
+		QFE_PROFILE_SCOPE;
 		SceneManager* sceneManager = engineCore_->GetSceneManager();
 		TransformData data = {};
 		if (sceneManager && sceneManager->GetEntityManager()->HasComponent<Transform>(entityId)) {
@@ -157,6 +168,7 @@ namespace QFE {
 	}
 
 	void WindowsBridgeCore::SetTransform(uint32_t entityId, const TransformData& data) {
+		QFE_PROFILE_SCOPE;
 		SceneManager* sceneManager = engineCore_->GetSceneManager();
 		if (sceneManager && sceneManager->GetEntityManager()->HasComponent<Transform>(entityId)) {
 			Transform& t = sceneManager->GetEntityManager()->GetComponent<Transform>(entityId);
@@ -167,6 +179,7 @@ namespace QFE {
 	}
 
 	ModelRenderInfo WindowsBridgeCore::GetModelRenderInfo(uint32_t entityId) {
+		QFE_PROFILE_SCOPE;
 		SceneManager* sceneManager = engineCore_->GetSceneManager();
 		AssetManager* assetManager = engineCore_->GetAssetManager();
 		ModelRenderInfo info = {};
@@ -198,6 +211,7 @@ namespace QFE {
 	}
 
 	void WindowsBridgeCore::SetMeshMaterial(uint32_t entityId, int meshIndex, const float color[4], float shininess) {
+		QFE_PROFILE_SCOPE;
 		AssetManager* assetManager = engineCore_->GetAssetManager();
 		SceneManager* sceneManager = engineCore_->GetSceneManager();
 		if (sceneManager && assetManager && sceneManager->GetEntityManager()->HasComponent<ModelHandle>(entityId)) {
@@ -214,6 +228,7 @@ namespace QFE {
 	}
 
 	void WindowsBridgeCore::SetMeshLight(uint32_t entityId, int meshIndex, const float color[4], const float direction[3]) {
+		QFE_PROFILE_SCOPE;
 		AssetManager* assetManager = engineCore_->GetAssetManager();
 		SceneManager* sceneManager = engineCore_->GetSceneManager();
 		if (sceneManager && assetManager && sceneManager->GetEntityManager()->HasComponent<ModelHandle>(entityId)) {
@@ -230,6 +245,7 @@ namespace QFE {
 	}
 
 	void WindowsBridgeCore::ChangeModel(uint32_t entityId, const std::string& modelName) {
+		QFE_PROFILE_SCOPE;
 		SceneManager* sceneManager = engineCore_->GetSceneManager();
 		if (sceneManager) {
 			sceneManager->ChangeEntityModel(entityId, modelName);
@@ -237,6 +253,7 @@ namespace QFE {
 	}
 
 	ParticleInfo WindowsBridgeCore::GetParticleInfo(uint32_t entityId) {
+		QFE_PROFILE_SCOPE;
 		SceneManager* sceneManager = engineCore_->GetSceneManager();
 		ParticleInfo info = {};
 		if (sceneManager && sceneManager->GetEntityManager()->HasComponent<ParticleComponent>(entityId)) {
@@ -248,6 +265,7 @@ namespace QFE {
 	}
 
 	SpriteInfo WindowsBridgeCore::GetSpriteInfo(uint32_t entityId) {
+		QFE_PROFILE_SCOPE;
 		SceneManager* sceneManager = engineCore_->GetSceneManager();
 		SpriteInfo info = {};
 		if (sceneManager && sceneManager->GetEntityManager()->HasComponent<SpriteData>(entityId)) {
@@ -262,6 +280,7 @@ namespace QFE {
 	}
 
 	void WindowsBridgeCore::SetSpriteInfo(uint32_t entityId, const SpriteInfo& info) {
+		QFE_PROFILE_SCOPE;
 		SceneManager* sceneManager = engineCore_->GetSceneManager();
 		if (sceneManager && sceneManager->GetEntityManager()->HasComponent<SpriteData>(entityId)) {
 			SpriteData& s = sceneManager->GetEntityManager()->GetComponent<SpriteData>(entityId);
@@ -280,6 +299,7 @@ namespace QFE {
 	}
 
 	CameraInfo WindowsBridgeCore::GetCameraInfo(uint32_t entityId) {
+		QFE_PROFILE_SCOPE;
 		SceneManager* sceneManager = engineCore_->GetSceneManager();
 		CameraInfo info = {};
 		if (sceneManager && sceneManager->GetEntityManager()->HasComponent<CameraData>(entityId)) {
@@ -292,6 +312,7 @@ namespace QFE {
 	}
 
 	void WindowsBridgeCore::SetCameraInfo(uint32_t entityId, const CameraInfo& info) {
+		QFE_PROFILE_SCOPE;
 		SceneManager* sceneManager = engineCore_->GetSceneManager();
 		if (sceneManager && sceneManager->GetEntityManager()->HasComponent<CameraData>(entityId)) {
 			CameraData& c = sceneManager->GetEntityManager()->GetComponent<CameraData>(entityId);
@@ -302,6 +323,7 @@ namespace QFE {
 	}
 
 	ForceData WindowsBridgeCore::GetForceData(uint32_t entityId) {
+		QFE_PROFILE_SCOPE;
 		SceneManager* sceneManager = engineCore_->GetSceneManager();
 		ForceData data = {};
 		if (sceneManager && sceneManager->GetEntityManager()->HasComponent<Force>(entityId)) {
@@ -317,6 +339,7 @@ namespace QFE {
 	}
 
 	void WindowsBridgeCore::SetForceData(uint32_t entityId, const ForceData& data) {
+		QFE_PROFILE_SCOPE;
 		SceneManager* sceneManager = engineCore_->GetSceneManager();
 		if (sceneManager && sceneManager->GetEntityManager()->HasComponent<Force>(entityId)) {
 			Force& f = sceneManager->GetEntityManager()->GetComponent<Force>(entityId);
@@ -330,6 +353,7 @@ namespace QFE {
 	}
 
 	SphereColliderInfo WindowsBridgeCore::GetSphereColliderInfo(uint32_t entityId) {
+		QFE_PROFILE_SCOPE;
 		SceneManager* sceneManager = engineCore_->GetSceneManager();
 		SphereColliderInfo info = {};
 		if (sceneManager && sceneManager->GetEntityManager()->HasComponent<SphereColliderData>(entityId)) {
@@ -346,6 +370,7 @@ namespace QFE {
 	}
 
 	void WindowsBridgeCore::SetSphereColliderInfo(uint32_t entityId, const SphereColliderInfo& info) {
+		QFE_PROFILE_SCOPE;
 		SceneManager* sceneManager = engineCore_->GetSceneManager();
 		if (sceneManager && sceneManager->GetEntityManager()->HasComponent<SphereColliderData>(entityId)) {
 			SphereColliderData& c = sceneManager->GetEntityManager()->GetComponent<SphereColliderData>(entityId);
@@ -360,6 +385,7 @@ namespace QFE {
 	}
 
 	AABBColliderInfo WindowsBridgeCore::GetAABBColliderInfo(uint32_t entityId) {
+		QFE_PROFILE_SCOPE;
 		SceneManager* sceneManager = engineCore_->GetSceneManager();
 		AABBColliderInfo info = {};
 		if (sceneManager && sceneManager->GetEntityManager()->HasComponent<AABBColliderData>(entityId)) {
@@ -376,6 +402,7 @@ namespace QFE {
 	}
 
 	void WindowsBridgeCore::SetAABBColliderInfo(uint32_t entityId, const AABBColliderInfo& info) {
+		QFE_PROFILE_SCOPE;
 		SceneManager* sceneManager = engineCore_->GetSceneManager();
 		if (sceneManager && sceneManager->GetEntityManager()->HasComponent<AABBColliderData>(entityId)) {
 			AABBColliderData& c = sceneManager->GetEntityManager()->GetComponent<AABBColliderData>(entityId);
@@ -390,6 +417,7 @@ namespace QFE {
 	}
 
 	std::vector<std::string> WindowsBridgeCore::GetCsharpClassNames(uint32_t entityId) {
+		QFE_PROFILE_SCOPE;
 		SceneManager* sceneManager = engineCore_->GetSceneManager();
 		std::vector<std::string> names;
 		if (sceneManager && sceneManager->GetEntityManager()->HasComponent<CsharpComponent>(entityId)) {
@@ -402,6 +430,7 @@ namespace QFE {
 	}
 
 	void WindowsBridgeCore::RemoveCsharpScript(uint32_t entityId, const std::string& className) {
+		QFE_PROFILE_SCOPE;
 		(void)className;
 		SceneManager* sceneManager = engineCore_->GetSceneManager();
 		if (sceneManager) {
@@ -410,6 +439,7 @@ namespace QFE {
 	}
 
 	void WindowsBridgeCore::AddCsharpScript(uint32_t entityId, const std::string& className) {
+		QFE_PROFILE_SCOPE;
 		SceneManager* sceneManager = engineCore_->GetSceneManager();
 		if (sceneManager) {
 			sceneManager->AddCsharpScript(entityId, className);
@@ -417,6 +447,7 @@ namespace QFE {
 	}
 
 	std::vector<std::string> WindowsBridgeCore::GetAvailableCsharpClasses() {
+		QFE_PROFILE_SCOPE;
 		SceneManager* sceneManager = engineCore_->GetSceneManager();
 		if (sceneManager && sceneManager->GetCsharpScriptExecutor()) {
 			return sceneManager->GetCsharpScriptExecutor()->GetAvailableScriptClasses();
@@ -426,6 +457,7 @@ namespace QFE {
 
 	void WindowsBridgeCore::ReCompileCsharpScripts()
 	{
+		QFE_PROFILE_SCOPE;
 		QFE_LOG("Recompiling C# scripts...");
 		SceneManager* sceneManager_ = engineCore_->GetSceneManager();
 		if (sceneManager_ && sceneManager_->GetCsharpScriptExecutor()) {
@@ -439,6 +471,7 @@ namespace QFE {
 	}
 
 	void WindowsBridgeCore::AddEmptyEntity() {
+		QFE_PROFILE_SCOPE;
 		SceneManager* sceneManager = engineCore_->GetSceneManager();
 		if (sceneManager) {
 			sceneManager->AddEmptyObject();
@@ -446,6 +479,7 @@ namespace QFE {
 	}
 
 	void WindowsBridgeCore::AddEntityFromFile(const std::string& filepath) {
+		QFE_PROFILE_SCOPE;
 		SceneManager* sceneManager = engineCore_->GetSceneManager();
 		if (sceneManager) {
 			sceneManager->AddEntity(filepath);
@@ -453,6 +487,7 @@ namespace QFE {
 	}
 
 	void WindowsBridgeCore::AddModelEntity(const std::string& filepath) {
+		QFE_PROFILE_SCOPE;
 		SceneManager* sceneManager = engineCore_->GetSceneManager();
 		if (sceneManager) {
 			sceneManager->AddModel(filepath);
@@ -460,6 +495,7 @@ namespace QFE {
 	}
 
 	void WindowsBridgeCore::AddSpriteEntity(const std::string& filepath) {
+		QFE_PROFILE_SCOPE;
 		SceneManager* sceneManager = engineCore_->GetSceneManager();
 		if (sceneManager) {
 			sceneManager->AddSprite(filepath);
@@ -467,6 +503,7 @@ namespace QFE {
 	}
 
 	void WindowsBridgeCore::AddParticleEmitterEntity(const std::string& filepath, uint32_t particleCount) {
+		QFE_PROFILE_SCOPE;
 		SceneManager* sceneManager = engineCore_->GetSceneManager();
 		if (sceneManager) {
 			sceneManager->AddParticleEmitter(filepath, particleCount);
@@ -474,12 +511,14 @@ namespace QFE {
 	}
 
 	void WindowsBridgeCore::AddCameraEntity() {
+		QFE_PROFILE_SCOPE;
 #ifdef QFE_OPTIMIZE_OFF
 		DebugLog("Can not add Camera.");
 #endif
 	}
 
 	void WindowsBridgeCore::CopyEntity(uint32_t entityId) {
+		QFE_PROFILE_SCOPE;
 		SceneManager* sceneManager = engineCore_->GetSceneManager();
 		if (sceneManager) {
 			sceneManager->CopyEntity(entityId);
@@ -487,6 +526,7 @@ namespace QFE {
 	}
 
 	void WindowsBridgeCore::SaveEntity(uint32_t entityId, std::string filename) {
+		QFE_PROFILE_SCOPE;
 		SceneManager* sceneManager = engineCore_->GetSceneManager();
 		if (sceneManager) {
 			sceneManager->SaveEntity(entityId, filename);
@@ -494,6 +534,7 @@ namespace QFE {
 	}
 
 	void WindowsBridgeCore::DeleteEntity(uint32_t entityId) {
+		QFE_PROFILE_SCOPE;
 		SceneManager* sceneManager = engineCore_->GetSceneManager();
 		if (sceneManager) {
 			sceneManager->DeleteEntity(entityId);
@@ -501,6 +542,7 @@ namespace QFE {
 	}
 
 	void WindowsBridgeCore::ParentChild(uint32_t parentEntityId, uint32_t childEntityId) {
+		QFE_PROFILE_SCOPE;
 		SceneManager* sceneManager = engineCore_->GetSceneManager();
 		if (sceneManager) {
 			sceneManager->ParentChild(parentEntityId, childEntityId);
@@ -508,6 +550,7 @@ namespace QFE {
 	}
 
 	void WindowsBridgeCore::Unparent(uint32_t entityId) {
+		QFE_PROFILE_SCOPE;
 		SceneManager* sceneManager = engineCore_->GetSceneManager();
 		if (sceneManager) {
 			sceneManager->Unparent(entityId);
@@ -515,6 +558,7 @@ namespace QFE {
 	}
 
 	uint32_t WindowsBridgeCore::GetDebugCameraEntityId() {
+		QFE_PROFILE_SCOPE;
 		if (!CameraManager::GetInstance()) {
 #ifdef QFE_OPTIMIZE_OFF
 			DebugLog("CameraManager is not initialized.");

--- a/project/engine/src/core/Profiler.cpp
+++ b/project/engine/src/core/Profiler.cpp
@@ -1,0 +1,52 @@
+#include "engine/include/core/Profiler.h"
+#include "engine/include/core/EngineDefines.h"
+
+namespace QFE {
+	void Profiler::Initialize() {
+		
+	}
+	void Profiler::Finalize() {
+		
+	}
+	void Profiler::FrameStart() {
+		frameStartTime_ = std::chrono::high_resolution_clock::now();
+	}
+	void Profiler::FrameEnd() {
+		frameEndTime_ = std::chrono::high_resolution_clock::now();
+		frameDuration_ = std::chrono::duration_cast<std::chrono::milliseconds>(frameEndTime_ - frameStartTime_);
+	}
+	void Profiler::ClearScopeProfiles()
+	{
+		scopeProfiles_.clear();
+	}
+	void Profiler::RecordScopeProfile(const std::string& scopeName, const std::chrono::milliseconds& duration)
+	{
+		QFE_LOG("Recorded scope profile: " + scopeName + " - " + std::to_string(duration.count()) + " ms", QFE::LogLevel::EngineInfo);
+		scopeProfiles_[scopeName].push_back(duration);
+		if (scopeProfiles_[scopeName].size() > maxProfileEntries_) {
+			scopeProfiles_[scopeName].pop_front();
+		}
+	}
+	const std::unordered_map<std::string, std::deque<std::chrono::milliseconds>>& Profiler::GetScopeProfiles() const
+	{
+		return scopeProfiles_;
+	}
+	std::chrono::milliseconds Profiler::GetFrameDuration() const
+	{
+		return frameDuration_;
+	}
+	std::chrono::milliseconds Profiler::GetAverageScopeDuration(const std::string& scopeName) const
+	{
+		auto it = scopeProfiles_.find(scopeName);
+		if (it == scopeProfiles_.end() || it->second.empty()) {
+			QFE_LOG("No profile data for scope: " + scopeName, QFE::LogLevel::Warning);
+			return std::chrono::milliseconds(0);
+		}
+
+		std::chrono::milliseconds totalDuration(0);
+		for (const auto& duration : it->second) {
+			totalDuration += duration;
+		}
+		return totalDuration / static_cast<int>(it->second.size());
+	}
+}

--- a/project/engine/src/core/Thread/ThreadPool.cpp
+++ b/project/engine/src/core/Thread/ThreadPool.cpp
@@ -1,7 +1,5 @@
 #include "engine/include/core/Thread/ThreadPool.h"
-#ifdef QFE_OPTIMIZE_OFF
-#include "engine/include/utility/DebugTool/DebugLog/MyDebugLog.h"
-#endif // QFE_OPTIMIZE_OFF
+#include "engine/include/core/EngineDefines.h"
 
 QFE::ThreadPool::ThreadPool() {
 	size_t threadCount = std::thread::hardware_concurrency();

--- a/project/engine/src/graphic/DirectXCommon/Descriptors/DescriptorGenerator.cpp
+++ b/project/engine/src/graphic/DirectXCommon/Descriptors/DescriptorGenerator.cpp
@@ -1,8 +1,7 @@
 #include "engine/include/graphic/DirectXCommon/Descriptors/DescriptorGenerator/DescriptorGenerator.h"
 #include <cassert>
-#ifdef QFE_OPTIMIZE_OFF
-#include "engine/include/utility/DebugTool/DebugLog/MyDebugLog.h"
-#endif // QFE_OPTIMIZE_OFF
+#include "engine/include/core/EngineDefines.h"
+
 using namespace QFE;
 void DescriptorGenerator::GenerateDescriptorHeap(Microsoft::WRL::ComPtr<ID3D12DescriptorHeap>& heap, ID3D12Device* device, const DescriptorGenerateConfig& config) {
 	assert(!heap && "Already generated");

--- a/project/engine/src/graphic/DirectXCommon/Descriptors/DescriptorHeapManager.cpp
+++ b/project/engine/src/graphic/DirectXCommon/Descriptors/DescriptorHeapManager.cpp
@@ -1,8 +1,7 @@
 #include "engine/include/graphic/DirectXCommon/Descriptors/DescriptorHeapManager.h"
 
-#ifdef QFE_OPTIMIZE_OFF
-#include "engine/include/utility/DebugTool/DebugLog/MyDebugLog.h"
-#endif // QFE_OPTIMIZE_OFF
+#include "engine/include/core/EngineDefines.h"
+
 using namespace QFE;
 void DescriptorHeapManager::Initialize(ID3D12Device* device) {
 #ifdef QFE_OPTIMIZE_OFF

--- a/project/engine/src/graphic/DirectXCommon/Descriptors/DsvDescriptorHeap.cpp
+++ b/project/engine/src/graphic/DirectXCommon/Descriptors/DsvDescriptorHeap.cpp
@@ -2,9 +2,9 @@
 #include "engine/include/graphic/DirectXCommon/Descriptors/DescriptorGenerator/DescriptorGenerator.h"
 #include "engine/include/graphic/DirectXCommon/Descriptors/CheckGenerateConfig/CheckGenerateConfig.h"
 #include "engine/include/utility/DirectX/GenerateDescriptorHandle.h"
-#ifdef QFE_OPTIMIZE_OFF
-#include "engine/include/utility/DebugTool/DebugLog/MyDebugLog.h"
-#endif // QFE_OPTIMIZE_OFF
+
+#include "engine/include/core/EngineDefines.h"
+
 using namespace QFE;
 void DsvDescriptorHeap::Initialize(ID3D12Device* device, UINT numDescriptors, bool shaderVisible) {
 	assert(device);

--- a/project/engine/src/graphic/DirectXCommon/Descriptors/RtvDescriptorHeap.cpp
+++ b/project/engine/src/graphic/DirectXCommon/Descriptors/RtvDescriptorHeap.cpp
@@ -3,9 +3,8 @@
 #include "engine/include/graphic/DirectXCommon/Descriptors/CheckGenerateConfig/CheckGenerateConfig.h"
 #include "engine/include/utility/DirectX/GenerateDescriptorHandle.h"
 
-#ifdef QFE_OPTIMIZE_OFF
-#include "engine/include/utility/DebugTool/DebugLog/MyDebugLog.h"
-#endif // QFE_OPTIMIZE_OFF
+#include "engine/include/core/EngineDefines.h"
+
 using namespace QFE;
 void RtvDescriptorHeap::Initialize(ID3D12Device* device, UINT numDescriptors, bool shaderVisible) {
 #ifdef QFE_OPTIMIZE_OFF

--- a/project/engine/src/graphic/DirectXCommon/Descriptors/SrvDescriptorHeap.cpp
+++ b/project/engine/src/graphic/DirectXCommon/Descriptors/SrvDescriptorHeap.cpp
@@ -4,9 +4,8 @@
 #include "engine/include/graphic/DirectXCommon/Descriptors/CheckGenerateConfig/CheckGenerateConfig.h"
 #include "engine/include/utility/DirectX/GenerateDescriptorHandle.h"
 
-#ifdef QFE_OPTIMIZE_OFF
-#include "engine/include/utility/DebugTool/DebugLog/MyDebugLog.h"
-#endif // QFE_OPTIMIZE_OFF
+#include "engine/include/core/EngineDefines.h"
+
 using namespace QFE;
 void SrvDescriptorHeap::Initialize(ID3D12Device* device, UINT numDescriptors, bool shaderVisible) {
 #ifdef QFE_OPTIMIZE_OFF

--- a/project/engine/src/graphic/DirectXCommon/DirectXCommandManager.cpp
+++ b/project/engine/src/graphic/DirectXCommon/DirectXCommandManager.cpp
@@ -1,9 +1,8 @@
 #include "engine/include/graphic/DirectXCommon/Command/DirectXCommandManager.h"
 #include <cassert>
 
-#ifdef QFE_OPTIMIZE_OFF
-#include "engine/include/utility/DebugTool/DebugLog/MyDebugLog.h"
-#endif // QFE_OPTIMIZE_OFF
+#include "engine/include/core/EngineDefines.h"
+
 using namespace QFE;
 void DirectXCommandManager::Initialize(ID3D12Device* device) {
 #ifdef QFE_OPTIMIZE_OFF

--- a/project/engine/src/graphic/DirectXCommon/DirectXCommon.cpp
+++ b/project/engine/src/graphic/DirectXCommon/DirectXCommon.cpp
@@ -11,9 +11,7 @@
 #include "engine/include/utility/String/MyString.h"
 #include "engine/include/core/EngineGlobalValue.h"
 
-#ifdef QFE_OPTIMIZE_OFF
-#include "engine/include/utility/DebugTool/DebugLog/MyDebugLog.h"
-#endif // QFE_OPTIMIZE_OFF
+#include "engine/include/core/EngineDefines.h"
 
 using namespace QFE;
 

--- a/project/engine/src/graphic/DirectXCommon/SwapChain.cpp
+++ b/project/engine/src/graphic/DirectXCommon/SwapChain.cpp
@@ -1,9 +1,7 @@
 #include "engine/include/graphic/DirectXCommon/SwapChain.h"
 #include <cassert>
 
-#ifdef QFE_OPTIMIZE_OFF
-#include "engine/include/utility/DebugTool/DebugLog/MyDebugLog.h"
-#endif // QFE_OPTIMIZE_OFF
+#include "engine/include/core/EngineDefines.h"
 
 namespace QFE {
 

--- a/project/engine/src/graphic/DirectXDevice.cpp
+++ b/project/engine/src/graphic/DirectXDevice.cpp
@@ -6,8 +6,9 @@
 #pragma comment(lib,"dxguid.lib")
 #pragma comment(lib,"dxcompiler.lib")
 
+#include "engine/include/core/EngineDefines.h"
+
 #ifdef QFE_OPTIMIZE_OFF
-#include "engine/include/utility/DebugTool/DebugLog/MyDebugLog.h"
 #include "engine/include/utility/String/MyString.h"
 #endif // QFE_OPTIMIZE_OFF
 

--- a/project/engine/src/graphic/Pipeline/PSO/RootParameter.cpp
+++ b/project/engine/src/graphic/Pipeline/PSO/RootParameter.cpp
@@ -1,8 +1,9 @@
 #include "engine/include/graphic/Pipeline/PSO/RootParameter.h"
 #include <cassert>
 
+#include "engine/include/core/EngineDefines.h"
+
 #ifdef QFE_OPTIMIZE_OFF
-#include "engine/include/utility/DebugTool/DebugLog/MyDebugLog.h"
 #include "engine/include/utility/String/DirectXStructToString.h"
 #endif // QFE_OPTIMIZE_OFF
 using namespace QFE;

--- a/project/engine/src/graphic/Pipeline/PSO/ShaderCompiler.cpp
+++ b/project/engine/src/graphic/Pipeline/PSO/ShaderCompiler.cpp
@@ -7,9 +7,7 @@
 #include <format>
 
 #include "engine/include/utility/FileSystems/FileUtility.h"
-#ifdef QFE_OPTIMIZE_OFF
-#include "engine/include/utility/DebugTool/DebugLog/MyDebugLog.h"
-#endif // QFE_OPTIMIZE_OFF
+#include "engine/include/core/EngineDefines.h"
 
 #include "engine/include/graphic/Pipeline/PSO/ShaderReflection.h"
 #include "engine/include/utility/FileSystems/FileUtility.h"

--- a/project/engine/src/graphic/Pipeline/PSO/ShaderReflection.cpp
+++ b/project/engine/src/graphic/Pipeline/PSO/ShaderReflection.cpp
@@ -1,7 +1,6 @@
 #include "engine/include/graphic/Pipeline/PSO/ShaderReflection.h"
-#ifdef QFE_OPTIMIZE_OFF
-#include "engine/include/utility/DebugTool/DebugLog/MyDebugLog.h"
-#endif // QFE_OPTIMIZE_OFF
+
+#include "engine/include/core/EngineDefines.h"
 
 #include <cassert>
 using namespace QFE;

--- a/project/engine/src/graphic/PostEffect/RenderingPostprocess.cpp
+++ b/project/engine/src/graphic/PostEffect/RenderingPostprocess.cpp
@@ -8,9 +8,9 @@
 
 #include <cassert>
 #include <algorithm>
+#include "engine/include/core/EngineDefines.h"
 
 #ifdef QFE_OPTIMIZE_OFF
-#include "engine/include/utility/DebugTool/DebugLog/MyDebugLog.h"
 #include "engine/include/utility/DebugTool/ImGui/ImGuiFlameController.h"
 #endif // QFE_OPTIMIZE_OFF
 

--- a/project/engine/src/graphic/ShaderBuffer/BufferGenerater/BufferGenerator.cpp
+++ b/project/engine/src/graphic/ShaderBuffer/BufferGenerater/BufferGenerator.cpp
@@ -1,7 +1,10 @@
 #include "engine/include/graphic/ShaderBuffer/BufferGenerater/BufferGenerator.h"
 #include <cassert>
+
+#include <format>
+#include "engine/include/core/EngineDefines.h"
+
 #ifdef QFE_OPTIMIZE_OFF
-#include "utility/DebugTool/DebugLog/MyDebugLog.h"
 #include "utility/String/MyString.h"
 #endif // QFE_OPTIMIZE_OFF
 using namespace QFE;
@@ -27,8 +30,6 @@ Microsoft::WRL::ComPtr<ID3D12Resource> BufferGenerator::Generate(ID3D12Device* d
 	hr;
 	assert(SUCCEEDED(hr));
 
-#ifdef QFE_OPTIMIZE_OFF
 	QFE_LOG(ConvertString(std::format(L"CreateBufferResource Bytes = {}", sizeInBytes)));
-#endif // QFE_OPTIMIZE_OFF
 	return vertexResource;
 }

--- a/project/engine/src/input/KeyConfig.cpp
+++ b/project/engine/src/input/KeyConfig.cpp
@@ -9,9 +9,7 @@
 #include <fstream>
 #include "engine/include/assets/AssetManager.h"
 
-#ifdef QFE_OPTIMIZE_OFF
-#include "engine/include/utility/DebugTool/DebugLog/MyDebugLog.h"
-#endif // QFE_OPTIMIZE_OFF
+#include "engine/include/core/EngineDefines.h"
 
 namespace QFE {
 

--- a/project/engine/src/input/XInput/XInputController.cpp
+++ b/project/engine/src/input/XInput/XInputController.cpp
@@ -5,9 +5,7 @@
 #include "engine/include/input/XInput/XInputController.h"
 #pragma comment(lib, "Xinput.lib")
 
-#ifdef QFE_OPTIMIZE_OFF
-#include "engine/include/utility/DebugTool/DebugLog/MyDebugLog.h"
-#endif // QFE_OPTIMIZE_OFF
+#include "engine/include/core/EngineDefines.h"
 
 #include <assert.h>
 #include <cmath>

--- a/project/engine/src/renderer/GraphRenderer.cpp
+++ b/project/engine/src/renderer/GraphRenderer.cpp
@@ -14,9 +14,7 @@
 #include <cassert>
 #include <numbers>
 
-#ifdef QFE_OPTIMIZE_OFF
-#include "engine/include/utility/DebugTool/DebugLog/MyDebugLog.h"
-#endif // QFE_OPTIMIZE_OFF
+#include "engine/include/core/EngineDefines.h"
 using namespace QFE::Render;
 
 /** @brief 初期化 */

--- a/project/engine/src/renderer/ModelRenderer.cpp
+++ b/project/engine/src/renderer/ModelRenderer.cpp
@@ -12,9 +12,7 @@
 
 #include "Engine/Resources/Shaders/ShaderStructs/hlslTypeToCpp.h"
 
-#ifdef QFE_OPTIMIZE_OFF
-#include "engine/include/utility/DebugTool/DebugLog/MyDebugLog.h"
-#endif // QFE_OPTIMIZE_OFF
+#include "engine/include/core/EngineDefines.h"
 
 namespace QFE {
 	namespace Render {

--- a/project/engine/src/scene/SceneCommand/SceneEntityCommandInvoker.cpp
+++ b/project/engine/src/scene/SceneCommand/SceneEntityCommandInvoker.cpp
@@ -2,9 +2,7 @@
 #include <chrono>
 using namespace QFE;
 
-#ifdef QFE_OPTIMIZE_OFF
-#include "engine/include/utility/DebugTool/DebugLog/MyDebugLog.h"
-#endif // QFE_OPTIMIZE_OFF
+#include "engine/include/core/EngineDefines.h"
 
 QFE::SceneEntityCommandInvoker::SceneEntityCommandInvoker(float commandTimeout) :
 	commandTimeout_(commandTimeout) {

--- a/project/engine/src/scene/SceneManager.cpp
+++ b/project/engine/src/scene/SceneManager.cpp
@@ -7,9 +7,7 @@
 #include <fstream>
 #include <string>
 
-#ifdef QFE_OPTIMIZE_OFF
-#include "engine/include/utility/DebugTool/DebugLog/MyDebugLog.h"
-#endif // QFE_OPTIMIZE_OFF
+#include "engine/include/core/EngineDefines.h"
 
 using namespace QFE;
 

--- a/project/engine/src/scene/SceneObject.cpp
+++ b/project/engine/src/scene/SceneObject.cpp
@@ -32,9 +32,7 @@
 #include "engine/include/renderer/SpriteRenderer.h"
 #include "engine/include/renderer/ParticleRenderer.h"
 
-#ifdef QFE_OPTIMIZE_OFF
-#include "engine/include/utility/DebugTool/DebugLog/MyDebugLog.h"
-#endif // QFE_OPTIMIZE_OFF
+#include "engine/include/core/EngineDefines.h"
 
 #include "Engine/include/scene/SceneCommand/SceneEntityCommands.h"
 #include "engine/include/scene/SceneObject.h"
@@ -58,6 +56,8 @@ SceneObject::~SceneObject() {
 }
 
 void SceneObject::Initialize() {
+	QFE_PROFILE_SCOPE;
+
 	assetManager_ = AssetManager::GetInstance();
 	assert(assetManager_);
 	isRequestedExit_ = false;
@@ -81,6 +81,8 @@ void SceneObject::Initialize() {
 }
 
 void SceneObject::Update() {
+	QFE_PROFILE_SCOPE;
+
 	frameStartCommandInvoker_.ExecuteCommands();
 
 	// ランタイム中のサブモジュールの更新
@@ -106,6 +108,8 @@ void SceneObject::Update() {
 }
 
 void SceneObject::PreDraw() {
+	QFE_PROFILE_SCOPE;
+
 	// 3Dモデルのカメラ位置更新
 	AssetManager* assetManager = AssetManager::GetInstance();
 	CameraManager* cameraManager = CameraManager::GetInstance();
@@ -134,6 +138,8 @@ void SceneObject::PreDraw() {
 }
 
 void SceneObject::Draw() {
+	QFE_PROFILE_SCOPE;
+
 	// 当たり判定の描画
 	ColliderManager::GetInstance()->Draw();
 
@@ -145,11 +151,15 @@ void SceneObject::Draw() {
 }
 
 void SceneObject::PostDraw() {
+	QFE_PROFILE_SCOPE;
+
 	// 後描画コマンド実行
 	postDrawCommandInvoker_.ExecuteCommands();
 }
 
 void SceneObject::EndFrame() {
+	QFE_PROFILE_SCOPE;
+
 	if (isRequestStopScript_) {
 		if (isRunningScript_) {
 			isRunningScript_ = false;
@@ -161,11 +171,15 @@ void SceneObject::EndFrame() {
 }
 
 void SceneObject::Finalize() {
+	QFE_PROFILE_SCOPE;
+
 	csharpScriptExecutor_.Finalize();
 	entityManager_.ResetEntiry();
 }
 
 void SceneObject::LoadScene(const std::string& sceneName) {
+	QFE_PROFILE_SCOPE;
+
 	std::string sceneNameCopy = sceneName;
 	// jsonファイルでない場合は拡張子を付ける
 	if (!sceneNameCopy.ends_with(".json") && !sceneNameCopy.ends_with(".scene")) {
@@ -222,6 +236,7 @@ void SceneObject::LoadScene(const std::string& sceneName) {
 }
 
 void SceneObject::SaveScene(const std::string& sceneName) {
+
 	QFE_LOG("SaveScene: " + sceneName);
 	AssetManager* assetManager = AssetManager::GetInstance();
 
@@ -268,6 +283,8 @@ void SceneObject::ResetScene() {
 }
 
 void SceneObject::RunScene() {
+	QFE_PROFILE_SCOPE;
+
 	if (!isRunningScript_) {
 		loadEntitiesBinary_.clear();
 
@@ -293,6 +310,8 @@ void SceneObject::ResumeScene() {
 }
 
 void SceneObject::StopScene() {
+	QFE_PROFILE_SCOPE;
+
 	if (isRequestStopScript_) { return; }
 	isRequestStopScript_ = true;
 	ColliderManager::GetInstance()->isRunning = false;

--- a/project/engine/src/utility/DebugTool/App/WinAppDebugCore.cpp
+++ b/project/engine/src/utility/DebugTool/App/WinAppDebugCore.cpp
@@ -1,8 +1,6 @@
 #include "engine/include/utility/DebugTool/App/WinAppDebugCore.h"
 #include "engine/include/utility/String/MyString.h"
-#ifdef QFE_OPTIMIZE_OFF
-#include "engine/include/utility/DebugTool/DebugLog/MyDebugLog.h"
-#endif // QFE_OPTIMIZE_OFF
+#include "engine/include/core/EngineDefines.h"
 
 
 #pragma comment(lib,"Dbghelp.lib")

--- a/project/engine/src/utility/DebugTool/DebugLog/MyDebugLog.cpp
+++ b/project/engine/src/utility/DebugTool/DebugLog/MyDebugLog.cpp
@@ -1,5 +1,6 @@
 #include "engine/include/utility/DebugTool/DebugLog/MyDebugLog.h"
 #include "engine/BuildInfo.h"
+#include "engine/include/core/EngineDefines.h"
 
 #include <cassert>
 

--- a/project/engine/src/utility/DebugTool/FrameCounter.cpp
+++ b/project/engine/src/utility/DebugTool/FrameCounter.cpp
@@ -5,9 +5,7 @@
 #include <timeapi.h>
 #pragma comment(lib,"winmm.lib") 
 
-#ifdef QFE_OPTIMIZE_OFF
-#include "engine/include/utility/DebugTool/DebugLog/MyDebugLog.h"
-#endif // QFE_OPTIMIZE_OFF
+#include "engine/include/core/EngineDefines.h"
 using namespace QFE;
 namespace {
 	const std::chrono::microseconds kMinTime(static_cast<uint64_t>(1000000.0f / 60.0f));

--- a/project/engine/src/utility/DebugTool/ImGui/ImGuiFlameController.cpp
+++ b/project/engine/src/utility/DebugTool/ImGui/ImGuiFlameController.cpp
@@ -1,7 +1,5 @@
 #include "engine/include/utility/DebugTool/ImGui/ImGuiFlameController.h"
-#ifdef QFE_OPTIMIZE_OFF
-#include "engine/include/utility/DebugTool/DebugLog/MyDebugLog.h"
-#endif // DEBUG
+#include "engine/include/core/EngineDefines.h"
 #include <cassert>
 using namespace QFE;
 ImGuiFlameController::ImGuiFlameController() {

--- a/project/engine/src/utility/String/StringLibrary.cpp
+++ b/project/engine/src/utility/String/StringLibrary.cpp
@@ -1,8 +1,6 @@
 #include "engine/include/utility/String/StringLibrary.h"
 
-#ifdef QFE_OPTIMIZE_OFF
-#include "engine/include/utility/DebugTool/DebugLog/MyDebugLog.h"
-#endif // QFE_OPTIMIZE_OFF
+#include "engine/include/core/EngineDefines.h"
 
 namespace QFE {
 

--- a/project/engine/src/window/WindowEventsManager/EventSystems/DropFileEvent.cpp
+++ b/project/engine/src/window/WindowEventsManager/EventSystems/DropFileEvent.cpp
@@ -2,8 +2,9 @@
 #include "engine/include/utility/String/MyString.h"
 #ifdef QFE_OPTIMIZE_OFF
 #include "engine/include/assets/AssetManager.h"
-#include "engine/include/utility/DebugTool/DebugLog/MyDebugLog.h"
 #endif // QFE_OPTIMIZE_OFF
+#include "engine/include/core/EngineDefines.h"
+
 using namespace QFE;
 DropFileEvent::DropFileEvent(nlohmann::json& data):IEvent(data) {}
 

--- a/project/engine/src/window/WindowEventsManager/EventSystems/ExitAppEvent.cpp
+++ b/project/engine/src/window/WindowEventsManager/EventSystems/ExitAppEvent.cpp
@@ -1,8 +1,6 @@
 #include "engine/include/window/windowEventsManager/EventSystems/ExitAppEvent.h"
-#ifdef QFE_OPTIMIZE_OFF
-#include "engine/include/utility/DebugTool/DebugLog/MyDebugLog.h"
-#include "engine/include/utility/String/MyString.h"
-#endif // QFE_OPTIMIZE_OFF
+#include "engine/include/core/EngineDefines.h"
+
 using namespace QFE;
 ExitAppEvent::ExitAppEvent(nlohmann::json& data):IEvent(data) {}
 

--- a/project/engine/src/window/WindowEventsManager/EventSystems/OnFocusEvent.cpp
+++ b/project/engine/src/window/WindowEventsManager/EventSystems/OnFocusEvent.cpp
@@ -1,11 +1,7 @@
 #include "engine/include/window/windowEventsManager/EventSystems/OnFocusEvent.h"
 
 #include "engine/include/scene/SceneManager.h"
-
-#ifdef QFE_OPTIMIZE_OFF
-#include "engine/include/utility/DebugTool/DebugLog/MyDebugLog.h"
-#include "engine/include/utility/String/MyString.h"
-#endif // QFE_OPTIMIZE_OFF
+#include "engine/include/core/EngineDefines.h"
 
 using namespace QFE;
 

--- a/project/engine/src/window/WindowEventsManager/WindowEventsManager.cpp
+++ b/project/engine/src/window/WindowEventsManager/WindowEventsManager.cpp
@@ -4,9 +4,10 @@
 #include "engine/include/window/windowEventsManager/eventSystems/ExitAppEvent.h"
 #include "engine/include/window/windowEventsManager/eventSystems/OnFocusEvent.h"
 
+#include "engine/include/core/EngineDefines.h"
+
 #ifdef QFE_OPTIMIZE_OFF
 #include "engine/include/utility/String/HwndConvertString.h"
-#include "engine/include/utility/DebugTool/DebugLog/MyDebugLog.h"
 #include "engine/include/utility/String/MyString.h"
 #include "Externals/imgui/imgui_impl_win32.h"
 extern IMGUI_IMPL_API LRESULT ImGui_ImplWin32_WndProcHandler(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);


### PR DESCRIPTION
- Profilerクラスを新規追加し、フレーム・スコープ単位の実行時間計測を実装
- EngineDefines.hを新設し、デバッグログ・プロファイル用マクロ(QFE_LOG/QFE_PROFILE_SCOPE)を集約
- 主要な関数（シーン制御・描画・エンティティ管理等）にQFE_PROFILE_SCOPEを追加し自動計測化
- ImGuiによるプロファイラ可視化UI（EngineProfileView）を追加。階層表示・平均/最新時間・割合・クリア機能を実装
- Profilerの初期化/終了/フレーム計測をWindowsEngineCoreのライフサイクルに組み込み
- 既存のデバッグログ用ifdef/インクルードを整理し、EngineDefines.hに統一
- MyDebugLog.hからマクロ定義を削除
- BuildInfo.hのビルド情報を更新
- プロファイリング導入に伴い、各種モジュールでインクルードやマクロの整理・統一を実施