### PR TITLE
エンティティ追加時のエラー処理とログ出力を改善

### DIFF
--- a/project/engine/BuildInfo.h
+++ b/project/engine/BuildInfo.h
@@ -1,5 +1,5 @@
 #pragma once 
-#define BUILD_COMMIT "82e7525a" 
-#define BUILD_BRANCH "feat-skybox" 
-#define BUILD_DATE "2026/05/11" 
-#define BUILD_TIME "23:54:12.69" 
+#define BUILD_COMMIT "9b24d430" 
+#define BUILD_BRANCH "develop" 
+#define BUILD_DATE "2026/05/12" 
+#define BUILD_TIME "06:50:02.11" 

--- a/project/engine/src/core/Error/ErrorList.cpp
+++ b/project/engine/src/core/Error/ErrorList.cpp
@@ -13,7 +13,7 @@ void QFE::DebugBreak() {
 void QFE::ReportUserError(const std::string& message, UserError error)
 {
 	error; message;
-	QFE_LOG("User Error: " + message);
+	QFE_LOG("User Error: " + message, LogLevel::Error);
 }
 
 void QFE::ReportSystemError(const std::string& message, SystemError error){

--- a/project/engine/src/scene/SceneObject.cpp
+++ b/project/engine/src/scene/SceneObject.cpp
@@ -514,9 +514,10 @@ uint32_t SceneObject::AddEntity(const std::string& entityName, bool useCache) {
 	std::ifstream ifs(sceneFilePath + entityName);
 	if (!ifs.is_open()) {
 		std::string errorMsg = "FaildOpenFile: " + sceneFilePath + entityName;
-		QFE_LOG(errorMsg, LogLevel::Error);
-		assert(false && "Faild Open Entity File.");
+		QFE_REPORT_USER_ERROR(errorMsg.c_str(), UserError::DeveloperError);
+		return UINT32_MAX;
 	}
+
 	nlohmann::json sceneJson;
 	ifs >> sceneJson;
 	ifs.close();
@@ -536,8 +537,7 @@ uint32_t SceneObject::AddEntity(const std::string& entityName, bool useCache) {
 
 uint32_t SceneObject::RunTimeAddEntity(const std::string& entityName) {
 	std::chrono::steady_clock::time_point start = std::chrono::steady_clock::now();
-	uint32_t entityId = AddEntity(entityName,true)
-		;
+	uint32_t entityId = AddEntity(entityName,true);
 
 	if (entityManager_.HasComponent<CsharpComponent>(entityId) && isRunningScript_) {
 		CsharpComponent& csharpComponent = entityManager_.GetComponent<CsharpComponent>(entityId);
@@ -546,9 +546,7 @@ uint32_t SceneObject::RunTimeAddEntity(const std::string& entityName) {
 		}
 	}
 	std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
-#ifdef QFE_OPTIMIZE_OFF
 	QFE_LOG("RunTimeAddEntity Time: " + std::to_string(std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count()) + " ms");
-#endif // QFE_OPTIMIZE_OFF
 	return entityId;
 }
 


### PR DESCRIPTION
- QFE_LOGでエラーレベルを明示的に指定するよう修正
- エンティティファイルが開けない場合、assertで停止せずUINT32_MAXを返すよう変更
- ユーザーエラー時にQFE_REPORT_USER_ERRORマクロを使用
- RunTimeAddEntity内のコード整形ミスを修正
- ビルド情報（コミットID、ブランチ名、日付、時刻）を更新