### PR TITLE
3Dモデル描画に環境マップ反射とダミーCubeMap対応を追加

### DIFF
--- a/project/engine/BuildInfo.h
+++ b/project/engine/BuildInfo.h
@@ -1,5 +1,5 @@
 #pragma once 
-#define BUILD_COMMIT "71abc22e" 
-#define BUILD_BRANCH "develop" 
-#define BUILD_DATE "2026/05/12" 
-#define BUILD_TIME "20:26:49.42" 
+#define BUILD_COMMIT "5b150291" 
+#define BUILD_BRANCH "feat-Environment-map" 
+#define BUILD_DATE "2026/05/13" 
+#define BUILD_TIME "08:15:37.08" 

--- a/project/engine/include/assets/2DTexture/TextureManager.h
+++ b/project/engine/include/assets/2DTexture/TextureManager.h
@@ -63,6 +63,9 @@ namespace QFE {
 		/// @brief デバッグ用に次のテクスチャハンドルを取得
 		[[nodiscard]] const int32_t GetNextTextureHandle() const { return textureHandle_; }
 
+		/// @brief ダミーの黒いキューブマップのハンドルを取得
+		[[nodiscard]] const int32_t GetDummyBlackCubeMapHandle() const;
+
 	private:
 		DirectX::ScratchImage Load(const std::string& filePath);
 		void LoadScratchImage(const std::string& filePath);
@@ -72,6 +75,9 @@ namespace QFE {
 		void EndUploadTextureData(ID3D12Resource* texture, ID3D12GraphicsCommandList* commandList);
 		void CreateShaderResourceView(const DirectX::TexMetadata& metadata, ID3D12Resource* textureResource);
 		void CreateSkyBoxShaderResourceView(const DirectX::TexMetadata& metadata, ID3D12Resource* textureResource);
+
+		/// @brief ダミーの黒いキューブマップを作成する
+		int32_t CreateDummyBlackCubeMap();
 
 		ID3D12Device* device_;
 		ID3D12GraphicsCommandList* commandList_;
@@ -89,6 +95,9 @@ namespace QFE {
 		int32_t textureHandle_;
 		SafeVector<Microsoft::WRL::ComPtr<ID3D12Resource>> intermediateResource_;
 		StringLibrary filePathLibrary_;
+
+		// エラー回避用テクスチャハンドル
+		int32_t dummyBlackCubeMapHandle_;
 	};
 
 }

--- a/project/engine/resources/shaders/ps/Object3d.PS.hlsl
+++ b/project/engine/resources/shaders/ps/Object3d.PS.hlsl
@@ -13,6 +13,7 @@ ConstantBuffer<Material> gMaterial : register(b0);
 ConstantBuffer<DirectionalLight> gDirectionalLight : register(b1);
 ConstantBuffer<CameraForGPU> gCamera : register(b2);
 Texture2D<float32_t4> gTexture : register(t0);
+TextureCube<float32_t4> gCubeTexture : register(t1);
 SamplerState gSampler : register(s0);
 
 struct PixelShaderOutput{
@@ -52,6 +53,11 @@ PixelShaderOutput main(VertexShaderOutput input)
             gDirectionalLight.color.rgb * gDirectionalLight.intensity * specularPow * float32_t3(1.0f, 1.0f, 1.0f);
         output.color.rgb = diffuse + specular;
         output.color.a = alpha;
+        
+        float32_t3 cameraToPosition = normalize(input.worldPosition - gCamera.cameraPosition);
+        float32_t3 reflection = reflect(-cameraToPosition, normalize(input.normal));
+        float32_t4 environmentColor = gCubeTexture.Sample(gSampler, reflection);
+        output.color.rgb += environmentColor.rgb;
     }
     else
     {

--- a/project/engine/src/assets/2DTexture/TextureManager.cpp
+++ b/project/engine/src/assets/2DTexture/TextureManager.cpp
@@ -20,6 +20,10 @@
 
 #include "engine/include/utility/FileSystems/FileUtility.h"
 
+namespace {
+	std::string kDummyBlackCubeMapKey = "DummyBlackCubeMap";
+}
+
 using namespace QFE;
 
 TextureManager::TextureManager() :
@@ -61,6 +65,9 @@ void TextureManager::Initialize(ID3D12Device* device, ID3D12GraphicsCommandList*
 	filePathLibrary_.Init("TextureFileName");
 
 	textureHandle_ = 0;
+
+	dummyBlackCubeMapHandle_ = CreateDummyBlackCubeMap();
+	filePathLibrary_.AddStringToLibrary(kDummyBlackCubeMapKey);
 }
 
 /// @brief 終了処理
@@ -73,6 +80,11 @@ void TextureManager::Finalize() {
 	intermediateResource_.clear();
 
 	CoUninitialize();
+}
+
+const int32_t QFE::TextureManager::GetDummyBlackCubeMapHandle() const
+{
+	return dummyBlackCubeMapHandle_;
 }
 
 DirectX::ScratchImage TextureManager::Load(const std::string& filePath) {
@@ -248,6 +260,44 @@ void QFE::TextureManager::CreateSkyBoxShaderResourceView(const DirectX::TexMetad
 	DescriptorHandles handles = srvDescriptorHeap_->AssignHeap(textureResource, srvDesc);
 	textureSrvHandleCPU_.push_back(handles.cpuHandle_);
 	textureSrvHandleGPU_.push_back(handles.gpuHandle_);
+}
+
+int32_t QFE::TextureManager::CreateDummyBlackCubeMap()
+{
+	// 空のScratchImageを作成
+	auto scratchImage = std::make_unique<DirectX::ScratchImage>();
+
+	// 1x1サイズ、RGBA8ビット、1キューブ(6面)、ミップマップレベル1で初期化
+	HRESULT hr = scratchImage->InitializeCube(DXGI_FORMAT_R8G8B8A8_UNORM, 1, 1, 1, 1);
+	if (!SUCCEEDED(hr)) {
+		QFE_REPORT_SYSTEM_ERROR("TextureManager: Failed to initialize dummy cube map", SystemError::Abort);
+	}
+	
+	// 全ての面のピクセルデータを0（黒）で塗りつぶす
+	const DirectX::Image* images = scratchImage->GetImages();
+	for (size_t i = 0; i < scratchImage->GetImageCount(); ++i) {
+		memset(images[i].pixels, 0, images[i].rowPitch * images[i].height);
+	}
+
+	// 生成したScratchImageを管理リストに追加
+	scratchImages_.push_back(std::move(scratchImage));
+	const DirectX::TexMetadata& metadata = scratchImages_.back()->GetMetadata();
+
+	// リソース作成
+	textureResources_.push_back(CreateTextureResource(metadata));
+
+	// CubeMap用のSRV作成
+	CreateSkyBoxShaderResourceView(metadata, textureResources_.back().Get());
+
+	textureHandle_++;
+
+	// データ転送
+	intermediateResource_.push_back(
+		UploadTextureData(textureResources_.back().Get(), *(scratchImages_.back().get()), commandList_));
+
+	QFE_LOG("TextureManager: Created Dummy Black CubeMap");
+
+	return textureHandle_ - 1;
 }
 
 void TextureManager::ReleaseIntermediateResources() {

--- a/project/engine/src/graphic/Pipeline/GraphicPipelineManager.cpp
+++ b/project/engine/src/graphic/Pipeline/GraphicPipelineManager.cpp
@@ -39,10 +39,12 @@ void GraphicPipelineManager::Initialize(
 	normalGameObjectRootParameter_.CreateRootParameter("PixelParameter", D3D12_ROOT_PARAMETER_TYPE_CBV, D3D12_SHADER_VISIBILITY_PIXEL, 0);
 	normalGameObjectRootParameter_.CreateRootParameter("VertexParameter", D3D12_ROOT_PARAMETER_TYPE_CBV, D3D12_SHADER_VISIBILITY_VERTEX, 0);
 	normalGameObjectRootParameter_.CreateRootParameter("TextureParameter", D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE, D3D12_SHADER_VISIBILITY_PIXEL, 0);
+	normalGameObjectRootParameter_.CreateRootParameter("CubeTextureParameter", D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE, D3D12_SHADER_VISIBILITY_PIXEL, 1);
 	normalGameObjectRootParameter_.CreateRootParameter("LightParameter", D3D12_ROOT_PARAMETER_TYPE_CBV, D3D12_SHADER_VISIBILITY_PIXEL, 1);
 	normalGameObjectRootParameter_.CreateRootParameter("CameraParameter", D3D12_ROOT_PARAMETER_TYPE_CBV, D3D12_SHADER_VISIBILITY_PIXEL, 2);
 
 	normalGameObjectRootParameter_.SetDescriptorRange("TextureParameter", D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 0);
+	normalGameObjectRootParameter_.SetDescriptorRange("CubeTextureParameter", D3D12_DESCRIPTOR_RANGE_TYPE_SRV, 1, 1);
 
 	// スプライトのルートパラメータ
 	spriteObjectRootParameter_.Initialize();

--- a/project/engine/src/renderer/ModelRenderer.cpp
+++ b/project/engine/src/renderer/ModelRenderer.cpp
@@ -3,6 +3,7 @@
  * @brief 3Dモデルのレンダリング機能の実装
  */
 
+#include "engine/include/scene/SceneManager.h"
 #include "engine/include/renderer/ModelRenderer.h"
 #include "engine/include/assets/AssetManager.h"
 #include "engine/include/assets/3DModel/Data/ModelRenderData.h"
@@ -11,6 +12,7 @@
 #include <cassert>
 
 #include "Engine/Resources/Shaders/ShaderStructs/hlslTypeToCpp.h"
+#include "engine/include/assets/3DModel/Data/SkyboxComponent.h"
 
 #include "engine/include/core/EngineDefines.h"
 
@@ -26,14 +28,27 @@ namespace QFE {
 				AssetManager* assetManager = AssetManager::GetInstance();
 				assert(assetManager && "AssetManager is nullptr.");
 
-				// TODO: modelHandle の有効性チェック(範囲チェック)が欠けている
+				// モデルハンドルから描画に必要なデータを取得
 				const ModelRenderData* modelDataPtr = assetManager->GetModelRenderData(modelHandle);
-				if(modelDataPtr == nullptr) {
-#ifdef QFE_OPTIMIZE_OFF
+				if (modelDataPtr == nullptr) {
 					QFE_LOG(std::string("Error: ModelRenderData is nullptr for modelHandle ") + std::to_string(modelHandle));
-#endif // QFE_OPTIMIZE_OFF
 					return;
 				}
+
+				// シーン上にキューブマップを持つエンティティが存在しない場合は、ダミーの黒いキューブマップを使用する
+				EntityManager* entityManager = SceneManager::GetInstance()->GetEntityManager();
+				assert(entityManager && "EntityManager is nullptr.");
+				int32_t cubeMapHandle = assetManager->GetTextureManager()->GetDummyBlackCubeMapHandle();
+				if (entityManager->HasComponentStrage<SkyboxComponent>()) {
+					ComponentStorage<SkyboxComponent>& skyboxStorage = entityManager->GetComponentStrage<SkyboxComponent>();
+					for (const auto& [entityId, skyboxComponent] : skyboxStorage.GetAllComponents()) {
+						if (skyboxComponent.textureHandle != UINT32_MAX) {
+							cubeMapHandle = skyboxComponent.textureHandle;
+							break;
+						}
+					}
+				}
+				
 				GpuBufferPool* gpuBufferPool = assetManager->GetGpuBufferPool();
 
 				PipelineStateObject* pso = GraphicPipelineManager::GetInstance()->GetTrianglePso(kBlendModeNormal);
@@ -58,9 +73,13 @@ namespace QFE {
 						gpuBufferPool->GetConstantBufferAddress<TransformationMatrix>(handle.wpvBufferHandle));
 					commandList->SetGraphicsRootDescriptorTable(2,
 						assetManager->GetTextureManager()->GetTextureSrvHandleGPU(handle.textureHandle));
-					commandList->SetGraphicsRootConstantBufferView(3,
-						gpuBufferPool->GetConstantBufferAddress<DirectionalLight>(handle.lightBufferHandle));
+
+					commandList->SetGraphicsRootDescriptorTable(3,
+						assetManager->GetTextureManager()->GetTextureSrvHandleGPU(cubeMapHandle));
+
 					commandList->SetGraphicsRootConstantBufferView(4,
+						gpuBufferPool->GetConstantBufferAddress<DirectionalLight>(handle.lightBufferHandle));
+					commandList->SetGraphicsRootConstantBufferView(5,
 						gpuBufferPool->GetConstantBufferAddress<CameraForGPU>(handle.cameraPosBufferHandle));
 					commandList->DrawInstanced(static_cast<UINT>(
 						assetManager->GetModelVertexResourceManager()->GetVertexBufferCount(handle.vertexBufferHandle)), 1, 0, 0);


### PR DESCRIPTION
- HLSLシェーダにキューブマップ環境反射処理を追加
- TextureManagerで黒いダミーCubeMapを自動生成・管理
- Skybox未設定時はダミーCubeMapを自動割り当て
- ルートシグネチャにCubeMap用SRVテーブルを追加
- ModelRendererでSkyboxComponentを参照しCubeMapを選択
- BuildInfo.hのビルド情報を更新
- 不要なコメントやifdefを整理