### PR TITLE
ECS: ComponentStorageをSparseSet化＆一括処理API追加

### DIFF
--- a/project/engine/BuildInfo.h
+++ b/project/engine/BuildInfo.h
@@ -1,5 +1,5 @@
 #pragma once 
-#define BUILD_COMMIT "5b150291" 
-#define BUILD_BRANCH "feat-Environment-map" 
+#define BUILD_COMMIT "242e370c" 
+#define BUILD_BRANCH "develop" 
 #define BUILD_DATE "2026/05/13" 
-#define BUILD_TIME "08:15:37.08" 
+#define BUILD_TIME "16:01:14.06" 

--- a/project/engine/include/assets/Script/Data/CsharpComponent.h
+++ b/project/engine/include/assets/Script/Data/CsharpComponent.h
@@ -19,6 +19,6 @@ namespace QFE {
 		void Deserialize(const nlohmann::json& json) override;
 		std::string GetTypeName() const override { return "CsharpComponent"; }
 
-		SafeVector<CsharpHandle> csharpHandles_;
+		std::vector<CsharpHandle> csharpHandles_;
 	};
 }

--- a/project/engine/include/core/Entity/Component/ComponentStorage.h
+++ b/project/engine/include/core/Entity/Component/ComponentStorage.h
@@ -1,6 +1,6 @@
 #pragma once
 #include "IComponentStorage.h"
-#include <unordered_map>
+#include "engine/include/utility/memory/SparseSets.h"
 #include <memory>
 #include <stdexcept>
 
@@ -9,9 +9,11 @@ namespace QFE {
 	template <typename T>
 	class ComponentStorage : public IComponentStorage {
 	private:
-		std::unordered_map<uint32_t, T> components;
+		SparseSet<T> components;
 
 	public:
+		ComponentStorage() = default;
+
 		auto begin() const { return components.begin(); }
 		auto end() const { return components.end(); }
 		auto begin() { return components.begin(); }
@@ -23,18 +25,14 @@ namespace QFE {
 			components[id] = component;
 		}
 		T& GetComponent(uint32_t id) {
-			auto it = components.find(id);
-			if (it != components.end()) {
-				return it->second;
+			T* ptr = components.find(id);
+			if (ptr) {
+				return *ptr;
 			}
 			throw std::runtime_error("Component not found");
 		}
 		T* GetComponentPtr(uint32_t id) {
-			auto it = components.find(id);
-			if (it != components.end()) {
-				return &(it->second);
-			}
-			return nullptr;
+			return components.find(id);
 		}
 		void RemoveComponent(uint32_t id) override {
 			components.erase(id);
@@ -43,14 +41,19 @@ namespace QFE {
 			return components;
 		}
 		bool HasComponent(uint32_t id) const {
-			return components.find(id) != components.end();
+			return components.Contains(id);
 		}
 		ComponentData* GetComponentDataPtr(uint32_t id) override {
-			auto it = components.find(id);
-			if (it != components.end()) {
-				return &(it->second);
-			}
-			return nullptr;
+			return components.find(id);
+		}
+
+		/// @brief 全ての有効なコンポーネントに対して関数を実行する。
+		void Each(const std::function<void(uint32_t, T&)>& func) {
+			components.Each(func);
+		}
+		/// @brief 全ての有効なコンポーネントに対して関数を実行する（const版）。
+		void Each(const std::function<void(uint32_t, const T&)>& func) const {
+			components.Each(func);
 		}
 	};
 

--- a/project/engine/include/core/Entity/Component/IComponentStorage.h
+++ b/project/engine/include/core/Entity/Component/IComponentStorage.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "engine/include/core/Entity/Component/ComponentData.h"
+#include <functional>
 
 namespace QFE {
 

--- a/project/engine/include/core/Entity/EntityManager.h
+++ b/project/engine/include/core/Entity/EntityManager.h
@@ -71,6 +71,28 @@ namespace QFE {
 		bool IsActiveEntity(uint32_t id) const {
 			return activeEntityIds_.find(id) != activeEntityIds_.end();
 		}
+
+		/// @brief 指定コンポーネントストレージの存在を確認
+		template <typename T>
+		bool HasComponentStrage() const {
+			size_t typeId = typeid(T).hash_code();
+			return componentStorages.find(typeId) != componentStorages.end();
+		}
+		/// @brief 指定エンティティが指定コンポーネントを持っているか判定
+		template <typename T>
+		bool HasComponent(uint32_t id) const {
+			if (id >= nextEntityId_) {
+				return false;
+			}
+
+			size_t typeId = typeid(T).hash_code();
+			if (componentStorages.find(typeId) != componentStorages.end()) {
+				const auto& storage = static_cast<const ComponentStorage<T>&>(*componentStorages.at(typeId));
+				return storage.HasComponent(id);
+			}
+			return false;
+		}
+
 		/// @brief 指定エンティティにコンポーネントを追加
 		template <typename T, typename... Args>
 		void EmplaceComponent(uint32_t id, Args&&... args) {
@@ -85,7 +107,7 @@ namespace QFE {
 		template <typename T>
 		T& GetComponent(uint32_t id) const {
 			size_t typeId = typeid(T).hash_code();
-			if (componentStorages.find(typeId) != componentStorages.end()) {
+			if (HasComponent<T>(id)) {
 				auto& storage = static_cast<ComponentStorage<T>&>(*componentStorages.at(typeId));
 				return storage.GetComponent(id);
 			}
@@ -95,7 +117,7 @@ namespace QFE {
 		template <typename T>
 		T* GetComponentPtr(uint32_t id) const {
 			size_t typeId = typeid(T).hash_code();
-			if (componentStorages.find(typeId) != componentStorages.end()) {
+			if (HasComponent<T>(id)) {
 				auto& storage = static_cast<ComponentStorage<T>&>(*componentStorages.at(typeId));
 				return storage.GetComponentPtr(id);
 			}
@@ -118,28 +140,26 @@ namespace QFE {
 			if (componentStorages.find(typeId) != componentStorages.end()) {
 				return static_cast<ComponentStorage<T>&>(*componentStorages.at(typeId));
 			}
-			throw std::runtime_error("Component strage not found");
+			QFE_REPORT_SYSTEM_ERROR("Component storage not found for type: " + std::string(typeid(T).name()), SystemError::Abort);
 		}
-		/// @brief 指定コンポーネントストレージの存在を確認
-		template <typename T>
-		bool HasComponentStrage() const {
-			size_t typeId = typeid(T).hash_code();
-			return componentStorages.find(typeId) != componentStorages.end();
-		}
-		/// @brief 指定エンティティが指定コンポーネントを持っているか判定
-		template <typename T>
-		bool HasComponent(uint32_t id) const {
-			if (id >= nextEntityId_) {
-				return false;
-			}
 
-			size_t typeId = typeid(T).hash_code();
-			if (componentStorages.find(typeId) != componentStorages.end()) {
-				const auto& storage = static_cast<const ComponentStorage<T>&>(*componentStorages.at(typeId));
-				return storage.HasComponent(id);
+		/// @brief 指定コンポーネントストレージに対して関数を実行
+		template <typename T>
+		void Each(const std::function<void(uint32_t, T&)>& func) {
+			if (HasComponentStrage<T>()) {
+				auto& storage = GetComponentStrage<T>();
+				storage.Each(func);
 			}
-			return false;
 		}
+		/// @brief 指定コンポーネントストレージに対して関数を実行（const版）
+		template <typename T>
+		void Each(const std::function<void(uint32_t, const T&)>& func) const {
+			if (HasComponentStrage<T>()) {
+				const auto& storage = GetComponentStrage<T>();
+				storage.Each(func);
+			}
+		}
+
 		/// @brief 次回生成エンティティIDを取得
 		uint32_t GetNextEntityId() const {
 			return nextEntityId_;

--- a/project/engine/include/core/Memory/SafeVector.h
+++ b/project/engine/include/core/Memory/SafeVector.h
@@ -12,7 +12,7 @@ namespace QFE {
 	class SafeVector : public IDynamicArray<T> {
 	public:
 		/// @brief コンストラクタ
-		explicit SafeVector(size_t size = 50) {
+		explicit SafeVector(size_t size = 512) {
 			// std::vectorで確保できるサイズを超えている場合は例外を投げる
 			if (size > data_.max_size()) {
 				QFE_REPORT_SYSTEM_ERROR("Requested size exceeds maximum capacity of SafeVector.", SystemError::Abort);

--- a/project/engine/include/utility/memory/SparseSets.h
+++ b/project/engine/include/utility/memory/SparseSets.h
@@ -1,27 +1,32 @@
 #pragma once
 #include "engine/include/core/Memory/SafeVector.h"
 #include <cstdint>
+#include <vector>
+#include <functional>
+
 namespace QFE {
 	/// @brief スパースセットコンテナ
 	template<typename T>
 	class SparseSet {
 	public:
 		SparseSet() = default;
+
 		/// @brief キーと値のペアを追加する。キーは自動的に割り当てられる。
 		uint32_t push_back(const T& value) {
-			// 未使用のキー（-1の場所）を探す
+			// 未使用のキー（UINT32_MAXの場所）を探す
 			uint32_t key = 0;
-			while (key < sparse_.size() && sparse_[key] != -1) {
+			while (key < sparse_.size() && sparse_[key] != UINT32_MAX) {
 				key++;
 			}
 			
-			// key に到達するまで push_back でサイズを拡大（空きは -1 で埋める）
+			// key に到達するまで push_back でサイズを拡大（空きは UINT32_MAX で埋める）
 			while (key >= sparse_.size()) {
-				sparse_.push_back(-1);
+				sparse_.push_back(UINT32_MAX);
 			}
 
+			dense_keys_.push_back(key);
 			dense_.push_back(value);
-			sparse_[key] = static_cast<int32_t>(dense_.size() - 1);
+			sparse_[key] = static_cast<uint32_t>(dense_.size() - 1);
 			return key;
 		}
 
@@ -29,56 +34,77 @@ namespace QFE {
 		void Insert(uint32_t key, const T& value) {
 			// 指定された key にアクセスできるようになるまでサイズを広げる
 			while (key >= sparse_.size()) {
-				sparse_.push_back(-1);
+				sparse_.push_back(UINT32_MAX);
 			}
 
-			if (sparse_[key] == -1) {
+			if (sparse_[key] == UINT32_MAX) {
+				dense_keys_.push_back(key);
 				dense_.push_back(value);
-				sparse_[key] = static_cast<int32_t>(dense_.size() - 1);
+				sparse_[key] = static_cast<uint32_t>(dense_.size() - 1);
 			} else {
 				dense_[sparse_[key]] = value;
 			}
 		}
+
 		/// @brief キーに対応する値を削除する。キーが存在しない場合は何もしない。
 		void Remove(uint32_t key) {
-			if (key < sparse_.size() && sparse_[key] != -1) {
-				int32_t index = sparse_[key];
+			if (key < sparse_.size() && sparse_[key] != UINT32_MAX) {
+				uint32_t index = sparse_[key];
+				
+				// O(1)削除：末尾の要素を削除対象の位置に移動する
 				dense_[index] = dense_.back();
+				dense_keys_[index] = dense_keys_.back();
+				
+				// 移動してきた要素の元のIDを引いて、sparse_の指す先を更新
+				uint32_t moved_key = dense_keys_[index];
+				sparse_[moved_key] = index;
+
+				// 末尾を削除
 				dense_.pop_back();
-				sparse_[key] = -1;
-				for (uint32_t i = 0; i < sparse_.size(); ++i) {
-					if (sparse_[i] == static_cast<int32_t>(dense_.size())) {
-						sparse_[i] = index;
-						break;
-					}
-				}
+				dense_keys_.pop_back();
+				sparse_[key] = UINT32_MAX;
 			}
 		}
+
 		/// @brief キーに対応する値へのポインタを取得する。キーが存在しない場合はnullptrを返す。
 		T* Get(uint32_t key) {
-			if (key < sparse_.size() && sparse_[key] != -1) {
+			if (key < sparse_.size() && sparse_[key] != UINT32_MAX) {
 				return &dense_[sparse_[key]];
 			}
 			return nullptr;
 		}
+
 		/// @brief キーに対応する要素が存在するかどうかを確認する。
 		bool Contains(uint32_t key) const {
-			return key < sparse_.size() && sparse_[key] != -1;
+			return key < sparse_.size() && sparse_[key] != UINT32_MAX;
 		}
+
 		/// @brief キーの一覧を取得する。
 		std::vector<uint32_t> Keys() const {
-			std::vector<uint32_t> keys;
-			for (uint32_t i = 0; i < sparse_.size(); ++i) {
-				if (sparse_[i] != -1) {
-					keys.push_back(i);
-				}
+			// dense_keys_ を使うことで、重いループ検索を使わずに即座にキー一覧を生成可能
+			return std::vector<uint32_t>(dense_keys_.begin(), dense_keys_.end());
+		}
+
+		/// @brief 全ての有効なコンポーネントに対して関数を実行する。
+		/// @param func (uint32_t id, T& component) を引数に取る関数オブジェクトまたはラムダ式
+		void Each(const std::function<void(uint32_t, T&)>& func) {
+			for (size_t i = 0; i < dense_.size(); ++i) {
+				func(dense_keys_[i], dense_[i]);
 			}
-			return keys;
+		}
+
+		/// @brief 読み取り専用のEach
+		/// @param func (uint32_t id, const T& component) を引数に取る関数オブジェクトまたはラムダ式
+		void Each(const std::function<void(uint32_t, const T&)>& func) const {
+			for (size_t i = 0; i < dense_.size(); ++i) {
+				func(dense_keys_[i], dense_[i]);
+			}
 		}
 
 		// 標準ライブラリ風インターフェース
 		void clear() {
 			sparse_.clear();
+			dense_keys_.clear();
 			dense_.clear();
 		}
 		auto begin() { return dense_.begin(); }
@@ -99,7 +125,8 @@ namespace QFE {
 			return dense_.at(sparse_.at(key));
 		}
 	private:
-		SafeVector<int32_t> sparse_;
+		SafeVector<uint32_t> sparse_;
+		SafeVector<uint32_t> dense_keys_;
 		SafeVector<T> dense_;
 	};
 } // namespace QFE

--- a/project/engine/src/collider/ColliderManager.cpp
+++ b/project/engine/src/collider/ColliderManager.cpp
@@ -38,32 +38,22 @@ namespace QFE {
 	void ColliderManager::Draw() {
 #ifdef QFE_OPTIMIZE_OFF
 		EntityManager* entityManager = SceneManager::GetInstance()->GetEntityManager();
-		if (entityManager->HasComponentStrage<SphereColliderData>()) {
-
-
-			auto& sphereColliderStrage = entityManager->GetComponentStrage<SphereColliderData>();
-			for (const auto& pair : sphereColliderStrage) {
-
-				const SphereColliderData& collider = pair.second;
-				if (collider.isDraw) {
-					Render::GraphRenderer::GetInstance()->DrawCircle(collider.sphere.center, collider.sphere.radius, { 0.0f, 1.0f, 0.0f, 1.0f }, 12);
-				}
+		entityManager->Each<SphereColliderData>([&](uint32_t entityId, SphereColliderData& collider) {
+			entityId; // 未使用
+			if (collider.isDraw) {
+				Render::GraphRenderer::GetInstance()->DrawCircle(
+					collider.sphere.center, collider.sphere.radius, { 0.0f, 1.0f, 0.0f, 1.0f }, 12);
 			}
-		}
+			});
 
-		if (entityManager->HasComponentStrage<AABBColliderData>()) {
-
-			auto& aabbColliderStrage = entityManager->GetComponentStrage<AABBColliderData>();
-			for (const auto& pair : aabbColliderStrage) {
-				const AABBColliderData& collider = pair.second;
-				if (collider.isDraw) {
-					Vector3 min = collider.aabb.center - collider.aabb.size * 0.5f;
-					Vector3 max = collider.aabb.center + collider.aabb.size * 0.5f;
-					Render::GraphRenderer::GetInstance()->DrawBox(min, max, { 0.0f, 1.0f, 0.0f, 1.0f });
-				}
+		entityManager->Each<AABBColliderData>([&](uint32_t entityId, AABBColliderData& collider) {
+			entityId; // 未使用
+			if (collider.isDraw) {
+				Vector3 min = collider.aabb.center - collider.aabb.size * 0.5f;
+				Vector3 max = collider.aabb.center + collider.aabb.size * 0.5f;
+				Render::GraphRenderer::GetInstance()->DrawBox(min, max, { 0.0f, 1.0f, 0.0f, 1.0f });
 			}
-
-		}
+			});
 #endif // QFE_OPTIMIZE_OFF
 	}
 
@@ -77,18 +67,17 @@ namespace QFE {
 			return;
 		}
 
-		auto& sphereColliderStrage = entityManager->GetComponentStrage<SphereColliderData>();
+		// SphereColliderDataを持つ全エンティティのIDを取得し、Transformコンポーネントがある場合はSphereの中心を更新する
 		std::vector<uint32_t> entityIds;
-		for (auto& pair : sphereColliderStrage) {
-			entityIds.push_back(pair.first);
-			if (entityManager->HasComponent<Transform>(pair.first)) {
-				Transform& transform = entityManager->GetComponent<Transform>(pair.first);
-				SphereColliderData& collider = entityManager->GetComponent<SphereColliderData>(pair.first);
+		entityManager->Each<SphereColliderData>([&](uint32_t entityId, SphereColliderData& collider) {
+			entityIds.push_back(entityId);
+			if (entityManager->HasComponent<Transform>(entityId)) {
+				Transform& transform = entityManager->GetComponent<Transform>(entityId);
 				collider.sphere.center = transform.translate;
 				collider.isOldHit = collider.isHit;
 				collider.isHit = false;
 			}
-		}
+			});
 
 		// エンジンが停止中なら当たり判定を行わない
 		if (!isRunning) {
@@ -171,18 +160,17 @@ namespace QFE {
 		if (!entityManager->HasComponentStrage<AABBColliderData>()) {
 			return;
 		}
-		auto& aabbColliderStrage = entityManager->GetComponentStrage<AABBColliderData>();
+
 		std::vector<uint32_t> entityIds;
-		for (auto& pair : aabbColliderStrage) {
-			entityIds.push_back(pair.first);
-			if (entityManager->HasComponent<Transform>(pair.first)) {
-				Transform& transform = entityManager->GetComponent<Transform>(pair.first);
-				AABBColliderData& collider = entityManager->GetComponent<AABBColliderData>(pair.first);
+		entityManager->Each<AABBColliderData>([&](uint32_t entityId, AABBColliderData& collider) {
+			entityIds.push_back(entityId);
+			if (entityManager->HasComponent<Transform>(entityId)) {
+				Transform& transform = entityManager->GetComponent<Transform>(entityId);
 				collider.aabb.center = transform.translate;
 				collider.isOldHit = collider.isHit;
 				collider.isHit = false;
 			}
-		}
+			});
 		// エンジンが停止中なら当たり判定を行わない
 		if (!isRunning) {
 			return;
@@ -293,36 +281,27 @@ namespace QFE {
 
 	void ColliderManager::SphereToAABBUpdate() {
 		EntityManager* entityManager = SceneManager::GetInstance()->GetEntityManager();
-		if (!entityManager->HasComponentStrage<SphereColliderData>()) {
-			return;
-		}
-		if (!entityManager->HasComponentStrage<AABBColliderData>()) {
-			return;
-		}
-		auto& sphereColliderStrage = entityManager->GetComponentStrage<SphereColliderData>();
-		auto& aabbColliderStrage = entityManager->GetComponentStrage<AABBColliderData>();
 		std::vector<uint32_t> sphereEntityIds;
-		for (auto& pair : sphereColliderStrage) {
-			sphereEntityIds.push_back(pair.first);
-			if (entityManager->HasComponent<Transform>(pair.first)) {
-				Transform& transform = entityManager->GetComponent<Transform>(pair.first);
-				SphereColliderData& collider = entityManager->GetComponent<SphereColliderData>(pair.first);
+		entityManager->Each<SphereColliderData>([&](uint32_t entityId, SphereColliderData& collider) {
+			if (entityManager->HasComponent<Transform>(entityId)) {
+				Transform& transform = entityManager->GetComponent<Transform>(entityId);
 				collider.sphere.center = transform.translate;
 				collider.isOldHit = collider.isHit;
 				collider.isHit = false;
+				sphereEntityIds.push_back(entityId);
 			}
-		}
+			});
 		std::vector<uint32_t> aabbEntityIds;
-		for (auto& pair : aabbColliderStrage) {
-			aabbEntityIds.push_back(pair.first);
-			if (entityManager->HasComponent<Transform>(pair.first)) {
-				Transform& transform = entityManager->GetComponent<Transform>(pair.first);
-				AABBColliderData& collider = entityManager->GetComponent<AABBColliderData>(pair.first);
+		entityManager->Each<AABBColliderData>([&](uint32_t entityId, AABBColliderData& collider) {
+			if (entityManager->HasComponent<Transform>(entityId)) {
+				Transform& transform = entityManager->GetComponent<Transform>(entityId);
 				collider.aabb.center = transform.translate;
 				collider.isOldHit = collider.isHit;
 				collider.isHit = false;
+				aabbEntityIds.push_back(entityId);
 			}
-		}
+			});
+	
 		// エンジンが停止中なら当たり判定を行わない
 		if (!isRunning) {
 			return;
@@ -346,17 +325,13 @@ namespace QFE {
 
 					// タグマスクが衝突不可か
 					if (colliderTagMask_.IsCollidable(objA->tag, objB->tag)) {
-#ifdef QFE_OPTIMIZE_OFF
 						QFE_LOG(std::format("Collider Tag Mismatch between Entity {} and Entity {}", sphereId, aabbId));
-#endif // QFE_OPTIMIZE_OFF
 						continue;
 					}
 
 					// 衝突イベントを発生させるレイヤーか
 					if ((sphereCollider.eventColliderLayer & aabbCollider.colliderLayer) == 0) {
-#ifdef QFE_OPTIMIZE_OFF
 						QFE_LOG(std::format("Collider Event Layer Mismatch between Entity {} and Entity {}", sphereId, aabbId));
-#endif // QFE_OPTIMIZE_OFF
 						continue;
 					}
 
@@ -366,9 +341,7 @@ namespace QFE {
 
 					// 反発しうるレイヤーか
 					if ((sphereCollider.colliderLayer & aabbCollider.eventColliderLayer) == 0) {
-#ifdef QFE_OPTIMIZE_OFF
 						QFE_LOG(std::format("Collider Repulsion Layer Mismatch between Entity{} and Entity {}", sphereId, aabbId));
-#endif // QFE_OPTIMIZE_OFF
 						continue;
 					}
 

--- a/project/engine/src/physics/PhysicsManager.cpp
+++ b/project/engine/src/physics/PhysicsManager.cpp
@@ -18,17 +18,10 @@ void PhysicsManager::Initialize() {
 /** @brief 更新 */
 void PhysicsManager::Update() {
 	EntityManager* entityManager = SceneManager::GetInstance()->GetEntityManager();
-	if (!entityManager->HasComponentStrage<Force>()) {
-		return;
-	}
 
-	const auto& forceStrage = entityManager->GetComponentStrage<Force>();
-	for (const auto& force : forceStrage) {
-		uint32_t entityId = force.first;
-		Force& forceComp = entityManager->GetComponent<Force>(entityId);
+	entityManager->Each<Force>([&](uint32_t entityId, Force& forceComp) {
 		// 加速度のリセット
 		forceComp.acceleration = Vector3::Zero();
-
 		// 重力
 		if (forceComp.isGravity) {
 			forceComp.acceleration.y += -9.8f * EngineGlobalValue::deltaTime * forceComp.gravityStrength; 
@@ -43,7 +36,7 @@ void PhysicsManager::Update() {
 		// 摩擦力の計算
 		float frictionFactor = std::exp(-forceComp.friction * EngineGlobalValue::deltaTime);
 		forceComp.velocity = forceComp.velocity * frictionFactor;
-	}
+		});
 }
 
 /** @brief 終了処理 */

--- a/project/engine/src/renderer/ModelRenderer.cpp
+++ b/project/engine/src/renderer/ModelRenderer.cpp
@@ -38,16 +38,13 @@ namespace QFE {
 				// シーン上にキューブマップを持つエンティティが存在しない場合は、ダミーの黒いキューブマップを使用する
 				EntityManager* entityManager = SceneManager::GetInstance()->GetEntityManager();
 				assert(entityManager && "EntityManager is nullptr.");
+
+				// キューブマップのハンドルを初期化
 				int32_t cubeMapHandle = assetManager->GetTextureManager()->GetDummyBlackCubeMapHandle();
-				if (entityManager->HasComponentStrage<SkyboxComponent>()) {
-					ComponentStorage<SkyboxComponent>& skyboxStorage = entityManager->GetComponentStrage<SkyboxComponent>();
-					for (const auto& [entityId, skyboxComponent] : skyboxStorage.GetAllComponents()) {
-						if (skyboxComponent.textureHandle != UINT32_MAX) {
-							cubeMapHandle = skyboxComponent.textureHandle;
-							break;
-						}
-					}
-				}
+				entityManager->Each<SkyboxComponent>([&](uint32_t entityId, SkyboxComponent& skyboxComp) {
+					cubeMapHandle = skyboxComp.textureHandle;
+					QFE_LOG(std::string("SkyboxComponent found on entityId ") + std::to_string(entityId) + ", textureHandle: " + std::to_string(skyboxComp.textureHandle));
+					});
 				
 				GpuBufferPool* gpuBufferPool = assetManager->GetGpuBufferPool();
 

--- a/project/engine/src/scene/SceneCommand/AllEntityRenderingCommand.cpp
+++ b/project/engine/src/scene/SceneCommand/AllEntityRenderingCommand.cpp
@@ -20,31 +20,22 @@ AllEntityRenderingCommand::AllEntityRenderingCommand(EntityManager& entityManage
 void AllEntityRenderingCommand::Execute()
 {
 	// Particleの描画
-	if (entityManager_.HasComponentStrage<ParticleComponent>()) {
-		const auto& particleStrage = entityManager_.GetComponentStrage<ParticleComponent>();
-		for (const auto& [entityId, particle] : particleStrage) {
-			Render::Particle::DrawParticles(&entityManager_,entityId);
-		}
-	}
+	entityManager_.Each<ParticleComponent>([&](uint32_t entityId, ParticleComponent& particle) {
+		particle;
+		Render::Particle::DrawParticles(&entityManager_, entityId);
+		});
+
 	// モデルの描画
-	if (entityManager_.HasComponentStrage<ModelHandle>()) {
-		const auto& modelStrage = entityManager_.GetComponentStrage<ModelHandle>();
-		for (const auto& [entityId, model] : modelStrage) {
-			Render::Model::DrawModel(model.handle);
-		}
-	}
-	// スプライトの描画（レイヤー順）
-	if (entityManager_.HasComponentStrage<SpriteData>()) {
-		const auto& spriteStrage = entityManager_.GetComponentStrage<SpriteData>();
-		std::vector<std::pair<uint32_t, SpriteData>> sortedSprites(spriteStrage.begin(), spriteStrage.end());
-		std::sort(sortedSprites.begin(), sortedSprites.end(),
-			[](const auto& a, const auto& b) {
-				return a.second.layer < b.second.layer;
-			});
-		for (const auto& [entityId, sprite] : sortedSprites) {
-			Render::Sprite::DrawSprites(&entityManager_, entityId);
-		}
-	}
+	entityManager_.Each<ModelHandle>([&](uint32_t entityId, ModelHandle& model) {
+		entityId; // 未使用
+		Render::Model::DrawModel(model.handle);
+		});
+
+	// スプライトの描画
+	entityManager_.Each<SpriteData>([&](uint32_t entityId, SpriteData& sprite) {
+		entityId; // 未使用
+		Render::Sprite::DrawSprites(&entityManager_, entityId);
+		});
 }
 
 void AllEntityRenderingCommand::Undo()

--- a/project/engine/src/scene/SceneCommand/AllSpriteResizeCommand.cpp
+++ b/project/engine/src/scene/SceneCommand/AllSpriteResizeCommand.cpp
@@ -10,15 +10,14 @@ AllSpriteResizeCommand::AllSpriteResizeCommand(EntityManager& em) : ISceneEntity
 
 void AllSpriteResizeCommand::Execute() {
 	AssetManager* assetManager_ = AssetManager::GetInstance();
-	if (entityManager_.HasComponentStrage<SpriteData>()) {
-		const auto& spriteStrage = entityManager_.GetComponentStrage<SpriteData>();
-		for (const auto& [entityId, sprite] : spriteStrage) {
-			Vector2 nowSize = assetManager_->GetSpriteManager()->GetSpriteSize(sprite.vertexBufferHandle);
-			if (sprite.width != nowSize.x || sprite.height != nowSize.y) {
-				assetManager_->GetSpriteManager()->ResizeSprite(sprite.vertexBufferHandle, sprite.width, sprite.height);
-			}
+
+	entityManager_.Each<SpriteData>([&](uint32_t entityId, SpriteData& spriteData) {
+		entityId; // 未使用
+		Vector2 nowSize = assetManager_->GetSpriteManager()->GetSpriteSize(spriteData.vertexBufferHandle);
+		if (spriteData.width != nowSize.x || spriteData.height != nowSize.y) {
+			assetManager_->GetSpriteManager()->ResizeSprite(spriteData.vertexBufferHandle, spriteData.width, spriteData.height);
 		}
-	}
+		});
 }
 
 void AllSpriteResizeCommand::Undo() {

--- a/project/engine/src/scene/SceneCommand/BillboardUpdateCommand.cpp
+++ b/project/engine/src/scene/SceneCommand/BillboardUpdateCommand.cpp
@@ -12,13 +12,11 @@ void QFE::BillboardUpdateCommand::Execute() {
 		return;
 	}
 
-	auto& billboardStorage = entityManager_.GetComponentStrage<BillboardComponent>();
-	for (auto& [entityId, billboardComp] : billboardStorage.GetAllComponents()) {
+	entityManager_.GetComponentStrage<BillboardComponent>().Each([&](uint32_t entityId, BillboardComponent& billboardComp) {
 		// トランスフォームコンポーネントが存在しない場合はスキップ
 		if (!entityManager_.HasComponent<Transform>(entityId)) {
-			continue;
+			return;
 		}
-
 		// トランスフォームコンポーネントを取得
 		Transform& transform = entityManager_.GetComponent<Transform>(entityId);
 		// ビルボードタイプに応じた処理を実行
@@ -27,7 +25,7 @@ void QFE::BillboardUpdateCommand::Execute() {
 		} else if (billboardComp.type_ == BillboardType::POINT) {
 			CameraPointBillboard(transform, billboardComp.rotateOffset_); // カメラの位置を向く
 		}
-	}
+		});
 }
 
 void QFE::BillboardUpdateCommand::Undo() {

--- a/project/engine/src/scene/SceneCommand/ParentUpdateCommand.cpp
+++ b/project/engine/src/scene/SceneCommand/ParentUpdateCommand.cpp
@@ -16,49 +16,7 @@ ParentUpdateCommand::ParentUpdateCommand(EntityManager& entityManager) : ISceneE
 
 void ParentUpdateCommand::Execute()
 {
-	AssetManager* assetManager = AssetManager::GetInstance();
-	std::vector<uint32_t> entities = entityManager_.GetActiveEntityIds();
-	for (auto entityId : entities) {
-		if (entityManager_.HasComponent<ParentData>(entityId)) {
-			ParentData& parentData = entityManager_.GetComponent<ParentData>(entityId);
-
-			uint32_t parentId = 0;
-			bool isFound = false;
-			if (entityManager_.HasComponentStrage<SceneObjectData>()) {
-				auto& strage = entityManager_.GetComponentStrage<SceneObjectData>();
-				for (const auto& [id, sceneObjData] : strage) {
-					if (sceneObjData.uniqueId == parentData.parentId) {
-						parentId = id;
-						isFound = true;
-						break;
-					}
-				}
-			}
-			if (!isFound) { continue; }
-
-			if (entityManager_.HasComponent<Transform>(parentId)) {
-				Transform& parentTransform = entityManager_.GetComponent<Transform>(parentId);
-				// Modelのワールド行列更新
-				if (entityManager_.HasComponent<ModelHandle>(entityId)) {
-					ModelHandle& modelHandle = entityManager_.GetComponent<ModelHandle>(entityId);
-					const ModelRenderData* modelData = assetManager->GetModelRenderData(modelHandle.handle);
-					for (const auto& meshData : modelData->meshRenderDataHandles) {
-						TransformationMatrix* wpvMatrix = assetManager->GetGpuBufferPool()->GetConstantBufferData<TransformationMatrix>(meshData.wpvBufferHandle);
-						wpvMatrix->World = Matrix4x4::Multiply(wpvMatrix->World, Matrix4x4::MakeAffineMatrix(
-							parentTransform.scale, parentTransform.rotate, parentTransform.translate));
-					}
-				}
-				// スプライトのワールド行列更新
-				if (entityManager_.HasComponent<SpriteData>(entityId)) {
-					SpriteData& spriteData = entityManager_.GetComponent<SpriteData>(entityId);
-					TransformationMatrix* wpvMatrix = assetManager->GetGpuBufferPool()->GetConstantBufferData<TransformationMatrix>(spriteData.wvpBufferHandle);
-					wpvMatrix->World = Matrix4x4::Multiply(wpvMatrix->World, Matrix4x4::MakeAffineMatrix(
-						parentTransform.scale, parentTransform.rotate, parentTransform.translate));
-				}
-			}
-
-		}
-	}
+	// 一時的に関数を削除
 }
 
 void ParentUpdateCommand::Undo()

--- a/project/engine/src/scene/SceneCommand/SpritePivotUpdateCommand.cpp
+++ b/project/engine/src/scene/SceneCommand/SpritePivotUpdateCommand.cpp
@@ -11,24 +11,22 @@ SpritePivotUpdateCommand::SpritePivotUpdateCommand(EntityManager& entityManager)
 void SpritePivotUpdateCommand::Execute()
 {
 	AssetManager* assetManager = AssetManager::GetInstance();
-	if (entityManager_.HasComponentStrage<SpriteData>()) {
-		auto& strage = entityManager_.GetComponentStrage<SpriteData>();
-		for (auto& [id, data] : strage) {
-			VertexData* vertexData = assetManager->GetSpriteManager()->GetVertexData(data.vertexBufferHandle);
-			float w = data.width;
-			float h = data.height;
-			// 中心を基準に頂点座標設定
-			Vector2 pivotOffset = Vector2(0.0f, 0.0f);
-			pivotOffset.x = -w * data.pivot.x;
-			pivotOffset.y = -h * data.pivot.y;
-			vertexData[0].position = { pivotOffset.x, pivotOffset.y, 0.0f,1.0f };
-			vertexData[1].position = { w + pivotOffset.x, pivotOffset.y, 0.0f ,1.0f };
-			vertexData[2].position = { pivotOffset.x, h + pivotOffset.y, 0.0f ,1.0f };
-			vertexData[3].position = { w + pivotOffset.x, h + pivotOffset.y, 0.0f ,1.0f };
-			vertexData[4].position = { pivotOffset.x, h + pivotOffset.y, 0.0f,1.0f };
-			vertexData[5].position = { w + pivotOffset.x, pivotOffset.y, 0.0f ,1.0f };
-		}
-	}
+	entityManager_.Each<SpriteData>([&](uint32_t entityId, SpriteData& spriteData) {
+		entityId; // 未使用
+		VertexData* vertexData = assetManager->GetSpriteManager()->GetVertexData(spriteData.vertexBufferHandle);
+		float w = spriteData.width;
+		float h = spriteData.height;
+		// 中心を基準に頂点座標設定
+		Vector2 pivotOffset = Vector2(0.0f, 0.0f);
+		pivotOffset.x = -w * spriteData.pivot.x;
+		pivotOffset.y = -h * spriteData.pivot.y;
+		vertexData[0].position = { pivotOffset.x, pivotOffset.y, 0.0f,1.0f };
+		vertexData[1].position = { w + pivotOffset.x, pivotOffset.y, 0.0f ,1.0f };
+		vertexData[2].position = { pivotOffset.x, h + pivotOffset.y, 0.0f ,1.0f };
+		vertexData[3].position = { w + pivotOffset.x, h + pivotOffset.y, 0.0f ,1.0f };
+		vertexData[4].position = { pivotOffset.x, h + pivotOffset.y, 0.0f,1.0f };
+		vertexData[5].position = { w + pivotOffset.x, pivotOffset.y, 0.0f ,1.0f };
+		});
 }
 
 void SpritePivotUpdateCommand::Undo()

--- a/project/engine/src/scene/SceneObject.cpp
+++ b/project/engine/src/scene/SceneObject.cpp
@@ -118,17 +118,15 @@ void SceneObject::PreDraw() {
 	cameraManager->Update();
 
 	// 3Dモデルのカメラ位置更新
-	if (entityManager_.HasComponentStrage<ModelHandle>()) {
-		auto& modelStrage = entityManager_.GetComponentStrage<ModelHandle>();
-		for (auto& model : modelStrage) {
-			const ModelRenderData* modelDataPtr = assetManager->GetModelRenderData(model.second.handle);
-			GpuBufferPool* gpuBufferPool = assetManager->GetGpuBufferPool();
-			for (const auto& meshRenderDataHandle : modelDataPtr->meshRenderDataHandles) {
-				CameraForGPU* camera = gpuBufferPool->GetConstantBufferData<CameraForGPU>(meshRenderDataHandle.cameraPosBufferHandle);
-				camera->cameraPosition = cameraManager->GetMainCamera().GetPosition();
-			}
+	entityManager_.Each<ModelHandle>([&](uint32_t entityId, ModelHandle& model) {
+		entityId; // 未使用
+		const ModelRenderData* modelDataPtr = assetManager->GetModelRenderData(model.handle);
+		GpuBufferPool* gpuBufferPool = assetManager->GetGpuBufferPool();
+		for (const auto& meshRenderDataHandle : modelDataPtr->meshRenderDataHandles) {
+			CameraForGPU* camera = gpuBufferPool->GetConstantBufferData<CameraForGPU>(meshRenderDataHandle.cameraPosBufferHandle);
+			camera->cameraPosition = cameraManager->GetMainCamera().GetPosition();
 		}
-	}
+		});
 
 	// システム上絶対やるべき前描画コマンド
 	preDrawCommandInvoker_.AddSystemCommand(std::make_unique<BillboardUpdateCommand>(*(GetEntityManager()), cameraManager->GetMainCameraTransform()));
@@ -146,12 +144,10 @@ void SceneObject::Draw() {
 	ColliderManager::GetInstance()->Draw();
 
 	// スカイボックスの描画
-	if (entityManager_.HasComponentStrage<SkyboxComponent>()) {
-		ComponentStorage<SkyboxComponent> skyboxCompStr = entityManager_.GetComponentStrage<SkyboxComponent>();
-		for (auto& skybox : skyboxCompStr) {
-			Render::Skybox::DrawSkybox(skybox.second);
-		}
-	}
+	entityManager_.Each<SkyboxComponent>([](uint32_t entityId, SkyboxComponent& skyboxComp) {
+		entityId; // 未使用
+		Render::Skybox::DrawSkybox(skyboxComp);
+		});
 
 	// 全描画コマンド追加
 	drawCommandInvoker_.AddSystemCommand(std::make_unique<AllEntityRenderingCommand>(*(GetEntityManager())));
@@ -654,25 +650,6 @@ void SceneObject::Unparent(uint32_t childId) {
 	if (!entityManager_.HasComponent<ParentData>(childId)) {
 		return;
 	}
-	ParentData& parentData = entityManager_.GetComponent<ParentData>(childId);
-	uint32_t parentId = 0;
-	bool isFound = false;
-	if (entityManager_.HasComponentStrage<SceneObjectData>()) {
-		auto& strage = entityManager_.GetComponentStrage<SceneObjectData>();
-		for (const auto& [id, sceneObjData] : strage) {
-			if (sceneObjData.uniqueId == parentData.parentId) {
-				parentId = id;
-				isFound = true;
-				break;
-			}
-		}
-	}
-	if (!isFound) { return; }
-	if (!entityManager_.HasComponent<Transform>(parentId) || !entityManager_.HasComponent<Transform>(childId)) {
-		entityManager_.RemoveComponent<ParentData>(childId);
-		return;
-	}
-
 	entityManager_.RemoveComponent<ParentData>(childId);
 }
 


### PR DESCRIPTION
ECSのコンポーネントストレージをstd::unordered_mapからSparseSetベースに全面移行し、メモリ効率とイテレーション性能を向上。SparseSetにO(1)操作とEach関数を実装し、ComponentStorage/EntityManagerにも一括処理APIを追加。各システムのforループをEachによるラムダ式処理に統一し、可読性・保守性を改善。SafeVectorの初期サイズ拡大やCsharpComponentのvector化、親子関係処理の一時簡略化、不要コードの整理も実施。ビルド情報も更新。