### PR TITLE
Csharpスクリプト生成の強化と例外処理の追加

### DIFF
--- a/project/engine/BuildInfo.h
+++ b/project/engine/BuildInfo.h
@@ -1,5 +1,5 @@
 #pragma once 
-#define BUILD_COMMIT "610727e3" 
-#define BUILD_BRANCH "refactor-CsLogic" 
+#define BUILD_COMMIT "c755f7ee" 
+#define BUILD_BRANCH "develop" 
 #define BUILD_DATE "2026/05/14" 
-#define BUILD_TIME "10:17:44.15" 
+#define BUILD_TIME "21:34:05.72" 

--- a/project/engine/include/assets/Script/CsharpScriptExecutor.h
+++ b/project/engine/include/assets/Script/CsharpScriptExecutor.h
@@ -36,6 +36,9 @@ namespace QFE {
 		/// @brief 終了処理（AppDomainをアンロード）
 		void Finalize();
 
+		/// @brief 即座にスクリプトインスタンスを作成,ランタイム中に呼び出すと仮想環境が壊れる可能性があるため、Userが直接呼び出すべきではない
+		void ForceCreateScriptInstance(uint32_t entityId, const std::string& className);
+
 		/// @brief スクリプトインスタンスを作成
 		/// @param entityId バインドするエンティティID
 		/// @param className クラス名（名前空間含む）
@@ -70,6 +73,7 @@ namespace QFE {
 		MonoMethod* gameLogicFrameStartMethod_ = nullptr; // GameLogicManagerのFrameStartメソッド
 		MonoMethod* gameLogicFrameEndMethod_ = nullptr; // GameLogicManagerのFrameEndメソッド
 		MonoMethod* gameLogicCreateScriptInstanceMethod_ = nullptr; // GameLogicManagerのCreateScriptInstanceメソッド
+		MonoMethod* gameLogicForceCreateScriptInstanceMethod_ = nullptr; // GameLogicManagerのForceCreateScriptInstanceメソッド
 
 		/// @brief アセンブリをロード
 		void LoadAssembly();

--- a/project/engine/include/assets/Script/QFElinker/CsharpOnQFELinker.h
+++ b/project/engine/include/assets/Script/QFElinker/CsharpOnQFELinker.h
@@ -44,7 +44,7 @@ namespace QFE::CsharpOnQFELinker {
 
 	// SceneObject
 	extern uint32_t GetEntityFromName(MonoString* entityName);
-    extern uint32_t CreateEntity(MonoString* entityName,Transform transform);
+    extern uint32_t CreateEntity(MonoString* entityName,Transform transform,uint32_t changeCount);
 	extern void LoadScene(MonoString* sceneName);
     extern void ChangeModel(uint32_t entityId, MonoString* modelName);
     extern void ChangeMesh(uint32_t entityId, MonoString* meshName);

--- a/project/engine/resources/EngineConfig.json
+++ b/project/engine/resources/EngineConfig.json
@@ -1,3 +1,3 @@
 {
-    "lastProjectName": "NewGameProject"
+    "lastProjectName": "XEVIOUS3D"
 }

--- a/project/engine/src/assets/Script/CsharpScriptExecutor.cpp
+++ b/project/engine/src/assets/Script/CsharpScriptExecutor.cpp
@@ -25,9 +25,7 @@ void CsharpScriptExecutor::Initialize(EntityManager* entityManager) {
 
 	// MonoRuntimeManagerが初期化されているか確認
 	if (!MonoRuntimeManager::GetInstance()->IsInitialized()) {
-#ifdef QFE_OPTIMIZE_OFF
 		QFE_LOG("MonoRuntimeManager is not initialized.", LogLevel::Error);
-#endif
 		return;
 	}
 
@@ -41,23 +39,17 @@ void CsharpScriptExecutor::Initialize(EntityManager* entityManager) {
 	domain_ = mono_domain_create_appdomain(domainName, nullptr);
 
 	if (!domain_) {
-#ifdef QFE_OPTIMIZE_OFF
 		QFE_LOG("Failed to create AppDomain for scene.", LogLevel::Error);
-#endif
 		return;
 	}
 
 	// ドメインを切り替え
 	if (!mono_domain_set(domain_, false)) {
-#ifdef QFE_OPTIMIZE_OFF
 		QFE_LOG("Failed to set AppDomain.", LogLevel::Error);
-#endif
 		return;
 	}
 
-#ifdef QFE_OPTIMIZE_OFF
 	QFE_LOG("CsharpScriptExecutor initialized with new AppDomain.");
-#endif
 
 	// アセンブリをロード
 	LoadAssembly();
@@ -72,13 +64,19 @@ void QFE::CsharpScriptExecutor::InitializeGameLogic(EntityManager* entityManager
 	entityManager->Each<CsharpComponent>([this](uint32_t entityId, CsharpComponent& csharpComponent) {
 		if (!csharpComponent.csharpHandles_.empty()) {
 			for(auto& handle : csharpComponent.csharpHandles_) {
-				CreateScriptInstance(entityId, handle.className_);
+				ForceCreateScriptInstance(entityId, handle.className_);
 			}
 		}
 		});
 
 	if (gameLogicManagerInstance_ && gameLogicInitializeMethod_) {
-		mono_runtime_invoke(gameLogicInitializeMethod_, gameLogicManagerInstance_, nullptr, nullptr);
+		try {
+			mono_runtime_invoke(gameLogicInitializeMethod_, gameLogicManagerInstance_, nullptr, nullptr);
+		}
+		catch (const std::exception& e) {
+			QFE_REPORT_SYSTEM_ERROR(
+				std::format("Exception occurred while invoking GameLogicManager.Initialize: {}", e.what()), SystemError::Abort());
+		}
 	}
 	else {
 		QFE_LOG("GameLogicManager is not properly initialized. Cannot call Initialize.", LogLevel::Error);
@@ -87,7 +85,13 @@ void QFE::CsharpScriptExecutor::InitializeGameLogic(EntityManager* entityManager
 
 void CsharpScriptExecutor::FrameStart() {
 	if (gameLogicManagerInstance_ && gameLogicFrameStartMethod_) {
-		mono_runtime_invoke(gameLogicFrameStartMethod_, gameLogicManagerInstance_, nullptr, nullptr);
+		try {
+			mono_runtime_invoke(gameLogicFrameStartMethod_, gameLogicManagerInstance_, nullptr, nullptr);
+		}
+		catch (const std::exception& e) {
+			QFE_REPORT_SYSTEM_ERROR(
+				std::format("Exception occurred while invoking FrameStart: {}", e.what()), SystemError::Abort());
+		}
 	}
 	else {
 		QFE_LOG("GameLogicManager is not properly initialized. Cannot call FrameStart.", LogLevel::Error);
@@ -96,13 +100,25 @@ void CsharpScriptExecutor::FrameStart() {
 
 void CsharpScriptExecutor::Update() {
 	if (gameLogicManagerInstance_ && gameLogicUpdateMethod_) {
-		mono_runtime_invoke(gameLogicUpdateMethod_, gameLogicManagerInstance_, nullptr, nullptr);
+		try {
+			mono_runtime_invoke(gameLogicUpdateMethod_, gameLogicManagerInstance_, nullptr, nullptr);
+		}
+		catch (const std::exception& e) {
+			QFE_REPORT_SYSTEM_ERROR(
+				std::format("Exception occurred while invoking Update: {}", e.what()), SystemError::Abort());
+		}
 	}
 }
 
 void CsharpScriptExecutor::FrameEnd() {
 	if (gameLogicManagerInstance_ && gameLogicFrameEndMethod_) {
-		mono_runtime_invoke(gameLogicFrameEndMethod_, gameLogicManagerInstance_, nullptr, nullptr);
+		try {
+			mono_runtime_invoke(gameLogicFrameEndMethod_, gameLogicManagerInstance_, nullptr, nullptr);
+		}
+		catch (const std::exception& e) {
+			QFE_REPORT_SYSTEM_ERROR(
+				std::format("Exception occurred while invoking FrameEnd: {}", e.what()), SystemError::Abort());
+		}
 	}
 	else {
 		QFE_LOG("GameLogicManager is not properly initialized. Cannot call FrameEnd.", LogLevel::Error);
@@ -111,9 +127,7 @@ void CsharpScriptExecutor::FrameEnd() {
 
 void CsharpScriptExecutor::LoadAssembly() {
 	if (!domain_) {
-#ifdef QFE_OPTIMIZE_OFF
 		QFE_LOG("Domain not initialized. Cannot load assembly.", LogLevel::Error);
-#endif
 		return;
 	}
 
@@ -121,13 +135,9 @@ void CsharpScriptExecutor::LoadAssembly() {
 	assembly_ = mono_domain_assembly_open(domain_, assemblyPath.c_str());
 
 	if (!assembly_) {
-#ifdef QFE_OPTIMIZE_OFF
 		QFE_LOG("Failed to load assembly: " + assemblyPath, LogLevel::Error);
-#endif
 	} else {
-#ifdef QFE_OPTIMIZE_OFF
 		QFE_LOG("Assembly loaded successfully: " + assemblyPath);
-#endif
 	}
 }
 
@@ -226,7 +236,15 @@ void CsharpScriptExecutor::CreateScriptInstance(uint32_t entityId, const std::st
 	void* args[2];
 	args[0] = &entityId;
 	args[1] = monoClassName;
-	mono_runtime_invoke(gameLogicCreateScriptInstanceMethod_, gameLogicManagerInstance_, args, &exception);
+	try {
+		QFE_LOG(std::format("Creating script instance for class '{}', entity ID: {}.", className, entityId));
+		mono_runtime_invoke(gameLogicCreateScriptInstanceMethod_, gameLogicManagerInstance_, args, &exception);
+	}
+	catch (const std::exception& e) {
+		QFE_REPORT_SYSTEM_ERROR(
+			std::format("Exception occurred while creating script instance for class '{}': {}", className, e.what()), SystemError::Abort());
+		return ;
+	}
 
 	if (exception) {
 		QFE_REPORT_USER_ERROR(std::format("Exception occurred while creating script instance for class '{}'.", className), UserError::DeveloperError);
@@ -290,6 +308,7 @@ void QFE::CsharpScriptExecutor::ResetGameLogicManager()
 		gameLogicUpdateMethod_ = mono_class_get_method_from_name(gameLogicManagerClass_, "UpdateAll", 0);
 		gameLogicFrameStartMethod_ = mono_class_get_method_from_name(gameLogicManagerClass_, "FrameStart", 0);
 		gameLogicFrameEndMethod_ = mono_class_get_method_from_name(gameLogicManagerClass_, "FrameEnd", 0);
+		gameLogicForceCreateScriptInstanceMethod_ = mono_class_get_method_from_name(gameLogicManagerClass_, "ForceCreateInstance", 2);
 
 		// メソッドが見つからない場合はエラーをログに出す
 		if (!gameLogicInitializeMethod_) {
@@ -328,4 +347,34 @@ void CsharpScriptExecutor::Finalize() {
 	}
 
 	QFE_LOG("CsharpScriptExecutor finalized.");
+}
+
+void QFE::CsharpScriptExecutor::ForceCreateScriptInstance(uint32_t entityId, const std::string& className)
+{
+	if (!gameLogicForceCreateScriptInstanceMethod_ || !gameLogicManagerInstance_) {
+		QFE_LOG("GameLogicManager is not properly initialized. Cannot force create script instance.", LogLevel::Error);
+		return;
+	}
+	MonoObject* exception = nullptr;
+	MonoString* monoClassName = mono_string_new(domain_, className.c_str());
+	if (monoClassName == nullptr) {
+		QFE_LOG(std::format("Failed to create MonoString for class name '{}'.", className), LogLevel::Error);
+		return;
+	}
+	void* args[2];
+	args[0] = &entityId;
+	args[1] = monoClassName;
+	try {
+		QFE_LOG(std::format("Force creating script instance for class '{}', entity ID: {}.", className, entityId));
+		mono_runtime_invoke(gameLogicForceCreateScriptInstanceMethod_, gameLogicManagerInstance_, args, &exception);
+	}
+	catch (const std::exception& e) {
+		QFE_REPORT_SYSTEM_ERROR(
+			std::format("Exception occurred while force creating script instance for class '{}': {}", className, e.what()), SystemError::Abort());
+		return;
+	}
+	if (exception) {
+		QFE_REPORT_USER_ERROR(std::format("Exception occurred while force creating script instance for class '{}'.", className), UserError::DeveloperError);
+		return;
+	}
 }

--- a/project/engine/src/assets/Script/QFElinker/CsharpOnQFELinker.cpp
+++ b/project/engine/src/assets/Script/QFElinker/CsharpOnQFELinker.cpp
@@ -233,7 +233,7 @@ uint32_t QFE::CsharpOnQFELinker::GetEntityFromName(MonoString* entityName) {
 	return entityId;
 }
 
-uint32_t QFE::CsharpOnQFELinker::CreateEntity(MonoString* entityName, Transform transform)
+uint32_t QFE::CsharpOnQFELinker::CreateEntity(MonoString* entityName, Transform transform, uint32_t changeCount)
 {
 	char* utf8_className = mono_string_to_utf8(entityName);
 	uint32_t entityId = SceneManager::GetInstance()->AddEntity(utf8_className);
@@ -241,7 +241,17 @@ uint32_t QFE::CsharpOnQFELinker::CreateEntity(MonoString* entityName, Transform 
 
 	EntityManager* entityManager = SceneManager::GetInstance()->GetEntityManager();
 	if (entityManager->HasComponent<TransformComponent>(entityId)) {
-		entityManager->GetComponent<TransformComponent>(entityId).transform = transform;
+		TransformComponent& transformComp = entityManager->GetComponent<TransformComponent>(entityId);
+
+		if (changeCount > 0) {
+			transformComp.transform.translate = transform.translate;
+		}
+		if (changeCount > 1) {
+			transformComp.transform.rotate = transform.rotate;
+		}
+		if (changeCount > 2) {
+			transformComp.transform.scale = transform.scale;
+		}
 	}
 
 	return entityId;

--- a/project/engine/src/scene/SceneObject.cpp
+++ b/project/engine/src/scene/SceneObject.cpp
@@ -486,6 +486,7 @@ void SceneObject::AddCsharpScript(uint32_t entityId, const std::string& classNam
 
 		CsharpHandle csharpHandle;
 		csharpHandle.className_ = className;
+		csharpComponent.csharpHandles_.push_back(csharpHandle);
 		if(isRunningScript_) {
 			csharpScriptExecutor_.CreateScriptInstance(entityId, className);
 		}


### PR DESCRIPTION
- CsharpScriptExecutorにForceCreateScriptInstanceを追加し、即時インスタンス生成をサポート
- GameLogicManagerのForceCreateInstanceメソッド取得処理を追加
- mono_runtime_invoke呼び出し箇所に例外処理を追加し、エラー時にシステムエラーとして報告
- CsharpOnQFELinker::CreateEntityにchangeCount引数を追加し、Transformの反映範囲を制御
- SceneObject::AddCsharpScriptでスクリプトハンドルの追加位置を修正
- ビルド情報・EngineConfig.jsonのプロジェクト名を更新
- QFE_OPTIMIZE_OFFによるログ出力を整理し、エラーハンドリングを簡素化