### PR TITLE
fix: C#の環境で起きた例外処理を確認できるようにする

### DIFF
--- a/project/engine/BuildInfo.h
+++ b/project/engine/BuildInfo.h
@@ -1,5 +1,5 @@
 #pragma once 
-#define BUILD_COMMIT "cfb5b801" 
-#define BUILD_BRANCH "develop" 
-#define BUILD_DATE "2026/05/15" 
-#define BUILD_TIME "14:50:59.20" 
+#define BUILD_COMMIT "5501cdfe" 
+#define BUILD_BRANCH "fix/issues-623-abort-csharp" 
+#define BUILD_DATE "2026/05/16" 
+#define BUILD_TIME "15:50:01.91" 

--- a/project/engine/src/assets/Script/CsharpCompiler.cpp
+++ b/project/engine/src/assets/Script/CsharpCompiler.cpp
@@ -48,9 +48,17 @@ void QFE::CompileCSharpProject(const std::string& csprojPath, const std::string&
 	std::string logPath = std::filesystem::path(csprojPath).parent_path().string() + "/build_log.txt";
 	QFE_LOG("Compiling C# project. Log will be saved to: " + logPath);
 	
-	// コマンド実行（出力をログファイルにリダイレクト）
-	std::string command = "dotnet build \"" + csprojPath + "\" -c Release -o \"" + std::filesystem::path(outputDllPath).parent_path().string() + "\" > \"" + logPath + "\" 2>&1";
+#ifdef QFE_OPTIMIZE_ON
+    // 最適化オンのときは標準エラー出力をコンソールに表示するため、リダイレクトは標準出力のみ
+    std::string command = 
+        "dotnet build \"" + csprojPath + "\" -c Release -o \"" + std::filesystem::path(outputDllPath).parent_path().string() + "\" > \"" + logPath + "\"";
 	QFE_LOG("Executing command: " + command);
+#else
+	// 最適化オフのときは標準エラー出力もログファイルにリダイレクトする
+    std::string command = 
+		"dotnet build \"" + csprojPath + "\" -c Debug -o \"" + std::filesystem::path(outputDllPath).parent_path().string() + "\" > \"" + logPath + "\" 2>&1";
+    QFE_LOG("Executing command: " + command);
+#endif
 
 	int result = system(command.c_str());
 	QFE_LOG("Command executed with result code: " + std::to_string(result));

--- a/project/engine/src/assets/Script/CsharpScriptExecutor.cpp
+++ b/project/engine/src/assets/Script/CsharpScriptExecutor.cpp
@@ -71,7 +71,12 @@ void QFE::CsharpScriptExecutor::InitializeGameLogic(EntityManager* entityManager
 
 	if (gameLogicManagerInstance_ && gameLogicInitializeMethod_) {
 		try {
-			mono_runtime_invoke(gameLogicInitializeMethod_, gameLogicManagerInstance_, nullptr, nullptr);
+			MonoObject* exception = nullptr;
+			mono_runtime_invoke(gameLogicInitializeMethod_, gameLogicManagerInstance_, nullptr, &exception);
+			if (exception) {
+				std::string msg = mono_string_to_utf8(mono_object_to_string(exception, nullptr));
+				QFE_REPORT_SYSTEM_ERROR("Exception occurred while invoking GameLogicManager.Initialize: " + msg, SystemError::Abort());
+			}
 		}
 		catch (const std::exception& e) {
 			QFE_REPORT_SYSTEM_ERROR(
@@ -86,7 +91,12 @@ void QFE::CsharpScriptExecutor::InitializeGameLogic(EntityManager* entityManager
 void CsharpScriptExecutor::FrameStart() {
 	if (gameLogicManagerInstance_ && gameLogicFrameStartMethod_) {
 		try {
-			mono_runtime_invoke(gameLogicFrameStartMethod_, gameLogicManagerInstance_, nullptr, nullptr);
+			MonoObject* exception = nullptr;
+			mono_runtime_invoke(gameLogicFrameStartMethod_, gameLogicManagerInstance_, nullptr, &exception);
+			if (exception) {
+				std::string msg = mono_string_to_utf8(mono_object_to_string(exception, nullptr));
+				QFE_REPORT_SYSTEM_ERROR("Exception occurred while invoking GameLogicManager.FrameStart: " + msg, SystemError::Abort());
+			}
 		}
 		catch (const std::exception& e) {
 			QFE_REPORT_SYSTEM_ERROR(
@@ -101,7 +111,12 @@ void CsharpScriptExecutor::FrameStart() {
 void CsharpScriptExecutor::Update() {
 	if (gameLogicManagerInstance_ && gameLogicUpdateMethod_) {
 		try {
-			mono_runtime_invoke(gameLogicUpdateMethod_, gameLogicManagerInstance_, nullptr, nullptr);
+			MonoObject* exception = nullptr;
+			mono_runtime_invoke(gameLogicUpdateMethod_, gameLogicManagerInstance_, nullptr, &exception);
+			if (exception) {
+				std::string msg = mono_string_to_utf8(mono_object_to_string(exception, nullptr));
+				QFE_REPORT_SYSTEM_ERROR("Exception occurred while invoking GameLogicManager.Update: " + msg, SystemError::Abort());
+			}
 		}
 		catch (const std::exception& e) {
 			QFE_REPORT_SYSTEM_ERROR(
@@ -113,7 +128,12 @@ void CsharpScriptExecutor::Update() {
 void CsharpScriptExecutor::FrameEnd() {
 	if (gameLogicManagerInstance_ && gameLogicFrameEndMethod_) {
 		try {
-			mono_runtime_invoke(gameLogicFrameEndMethod_, gameLogicManagerInstance_, nullptr, nullptr);
+			MonoObject* exception = nullptr;
+			mono_runtime_invoke(gameLogicFrameEndMethod_, gameLogicManagerInstance_, nullptr, &exception);
+			if (exception) {
+				std::string msg = mono_string_to_utf8(mono_object_to_string(exception, nullptr));
+				QFE_REPORT_SYSTEM_ERROR("Exception occurred while invoking GameLogicManager.FrameEnd: " + msg, SystemError::Abort());
+			}
 		}
 		catch (const std::exception& e) {
 			QFE_REPORT_SYSTEM_ERROR(
@@ -129,8 +149,12 @@ void QFE::CsharpScriptExecutor::CollisionUpdate()
 {
 	if (gameLogicManagerInstance_ && gameLogicCollisionUpdateMethod_) {
 		try {
-			mono_runtime_invoke(gameLogicCollisionUpdateMethod_, gameLogicManagerInstance_, nullptr, nullptr);
-
+			MonoObject* exception = nullptr;
+			mono_runtime_invoke(gameLogicCollisionUpdateMethod_, gameLogicManagerInstance_, nullptr, &exception);
+			if (exception) {
+				std::string msg = mono_string_to_utf8(mono_object_to_string(exception, nullptr));
+				QFE_REPORT_SYSTEM_ERROR("Exception occurred while invoking GameLogicManager.CollisionUpdate: " + msg, SystemError::Abort());
+			}
 		}
 		catch (const std::exception& e) {
 			QFE_REPORT_SYSTEM_ERROR(
@@ -255,6 +279,10 @@ void CsharpScriptExecutor::CreateScriptInstance(uint32_t entityId, const std::st
 	try {
 		QFE_LOG(std::format("Creating script instance for class '{}', entity ID: {}.", className, entityId));
 		mono_runtime_invoke(gameLogicCreateScriptInstanceMethod_, gameLogicManagerInstance_, args, &exception);
+		if(exception) {
+			std::string msg = mono_string_to_utf8(mono_object_to_string(exception, nullptr));
+			QFE_REPORT_SYSTEM_ERROR("Exception occurred while creating script instance for class '" + className + "': " + msg, SystemError::Abort());
+		}
 	}
 	catch (const std::exception& e) {
 		QFE_REPORT_SYSTEM_ERROR(
@@ -384,6 +412,10 @@ void QFE::CsharpScriptExecutor::ForceCreateScriptInstance(uint32_t entityId, con
 	try {
 		QFE_LOG(std::format("Force creating script instance for class '{}', entity ID: {}.", className, entityId));
 		mono_runtime_invoke(gameLogicForceCreateScriptInstanceMethod_, gameLogicManagerInstance_, args, &exception);
+		if(exception) {
+			std::string msg = mono_string_to_utf8(mono_object_to_string(exception, nullptr));
+			QFE_REPORT_SYSTEM_ERROR("Exception occurred while force creating script instance for class '" + className + "': " + msg, SystemError::Abort());
+		}
 	}
 	catch (const std::exception& e) {
 		QFE_REPORT_SYSTEM_ERROR(


### PR DESCRIPTION
メインプロセスでMonoがクラッシュした時点で再起不能なので
C#側で起きた例外メッセージをキャッチした瞬間ログを出してシステムごと止めます

Closes #623